### PR TITLE
Simplify brw_stats representation

### DIFF
--- a/src/obdfilter.rs
+++ b/src/obdfilter.rs
@@ -70,10 +70,7 @@ where
 mod tests {
     use super::ObdfilterStat::{Stats, Value};
     use super::*;
-    use brw_stats_parser::{BrwStats, BrwStatsBucketVals, BrwStatsBuckets};
-    use combine::error::StreamError;
-    use combine::stream::state::State;
-    use combine::{easy, error};
+    use brw_stats_parser::{BrwStats, BrwStatsBuckets};
 
     #[test]
     fn test_target_name() {
@@ -334,82 +331,34 @@ obdfilter.fs-OST0000.writethrough_cache_enable=1
                                 unit: "rpcs".to_string(),
                                 buckets: vec![
                                     BrwStatsBuckets {
-                                        name: "32".to_string(),
-                                        read: BrwStatsBucketVals {
-                                            count: "0".to_string(),
-                                            pct: "0".to_string(),
-                                            cum_pct: "0".to_string(),
-                                        },
-                                        write: BrwStatsBucketVals {
-                                            count: "1".to_string(),
-                                            pct: "11".to_string(),
-                                            cum_pct: "11".to_string(),
-                                        },
+                                        name: 32,
+                                        read: 0,
+                                        write: 1,
                                     },
                                     BrwStatsBuckets {
-                                        name: "64".to_string(),
-                                        read: BrwStatsBucketVals {
-                                            count: "0".to_string(),
-                                            pct: "0".to_string(),
-                                            cum_pct: "0".to_string(),
-                                        },
-                                        write: BrwStatsBucketVals {
-                                            count: "0".to_string(),
-                                            pct: "0".to_string(),
-                                            cum_pct: "11".to_string(),
-                                        },
+                                        name: 64,
+                                        read: 0,
+                                        write: 0,
                                     },
                                     BrwStatsBuckets {
-                                        name: "128".to_string(),
-                                        read: BrwStatsBucketVals {
-                                            count: "0".to_string(),
-                                            pct: "0".to_string(),
-                                            cum_pct: "0".to_string(),
-                                        },
-                                        write: BrwStatsBucketVals {
-                                            count: "0".to_string(),
-                                            pct: "0".to_string(),
-                                            cum_pct: "11".to_string(),
-                                        },
+                                        name: 128,
+                                        read: 0,
+                                        write: 0,
                                     },
                                     BrwStatsBuckets {
-                                        name: "256".to_string(),
-                                        read: BrwStatsBucketVals {
-                                            count: "0".to_string(),
-                                            pct: "0".to_string(),
-                                            cum_pct: "0".to_string(),
-                                        },
-                                        write: BrwStatsBucketVals {
-                                            count: "0".to_string(),
-                                            pct: "0".to_string(),
-                                            cum_pct: "11".to_string(),
-                                        },
+                                        name: 256,
+                                        read: 0,
+                                        write: 0,
                                     },
                                     BrwStatsBuckets {
-                                        name: "512".to_string(),
-                                        read: BrwStatsBucketVals {
-                                            count: "0".to_string(),
-                                            pct: "0".to_string(),
-                                            cum_pct: "0".to_string(),
-                                        },
-                                        write: BrwStatsBucketVals {
-                                            count: "0".to_string(),
-                                            pct: "0".to_string(),
-                                            cum_pct: "11".to_string(),
-                                        },
+                                        name: 512,
+                                        read: 0,
+                                        write: 0,
                                     },
                                     BrwStatsBuckets {
-                                        name: "1K".to_string(),
-                                        read: BrwStatsBucketVals {
-                                            count: "0".to_string(),
-                                            pct: "0".to_string(),
-                                            cum_pct: "0".to_string(),
-                                        },
-                                        write: BrwStatsBucketVals {
-                                            count: "8".to_string(),
-                                            pct: "88".to_string(),
-                                            cum_pct: "100".to_string(),
-                                        },
+                                        name: 1024,
+                                        read: 0,
+                                        write: 8,
                                     },
                                 ],
                             },
@@ -418,30 +367,14 @@ obdfilter.fs-OST0000.writethrough_cache_enable=1
                                 unit: "rpcs".to_string(),
                                 buckets: vec![
                                     BrwStatsBuckets {
-                                        name: "0".to_string(),
-                                        read: BrwStatsBucketVals {
-                                            count: "0".to_string(),
-                                            pct: "0".to_string(),
-                                            cum_pct: "0".to_string(),
-                                        },
-                                        write: BrwStatsBucketVals {
-                                            count: "6".to_string(),
-                                            pct: "66".to_string(),
-                                            cum_pct: "66".to_string(),
-                                        },
+                                        name: 0,
+                                        read: 0,
+                                        write: 6,
                                     },
                                     BrwStatsBuckets {
-                                        name: "1".to_string(),
-                                        read: BrwStatsBucketVals {
-                                            count: "0".to_string(),
-                                            pct: "0".to_string(),
-                                            cum_pct: "0".to_string(),
-                                        },
-                                        write: BrwStatsBucketVals {
-                                            count: "3".to_string(),
-                                            pct: "33".to_string(),
-                                            cum_pct: "100".to_string(),
-                                        },
+                                        name: 1,
+                                        read: 0,
+                                        write: 3,
                                     },
                                 ],
                             },
@@ -449,17 +382,9 @@ obdfilter.fs-OST0000.writethrough_cache_enable=1
                                 name: "discont_blocks".to_string(),
                                 unit: "rpcs".to_string(),
                                 buckets: vec![BrwStatsBuckets {
-                                    name: "0".to_string(),
-                                    read: BrwStatsBucketVals {
-                                        count: "0".to_string(),
-                                        pct: "0".to_string(),
-                                        cum_pct: "0".to_string(),
-                                    },
-                                    write: BrwStatsBucketVals {
-                                        count: "9".to_string(),
-                                        pct: "100".to_string(),
-                                        cum_pct: "100".to_string(),
-                                    },
+                                    name: 0,
+                                    read: 0,
+                                    write: 9,
                                 }],
                             },
                             BrwStats {
@@ -467,56 +392,24 @@ obdfilter.fs-OST0000.writethrough_cache_enable=1
                                 unit: "ios".to_string(),
                                 buckets: vec![
                                     BrwStatsBuckets {
-                                        name: "1".to_string(),
-                                        read: BrwStatsBucketVals {
-                                            count: "0".to_string(),
-                                            pct: "0".to_string(),
-                                            cum_pct: "0".to_string(),
-                                        },
-                                        write: BrwStatsBucketVals {
-                                            count: "1".to_string(),
-                                            pct: "11".to_string(),
-                                            cum_pct: "11".to_string(),
-                                        },
+                                        name: 1,
+                                        read: 0,
+                                        write: 1,
                                     },
                                     BrwStatsBuckets {
-                                        name: "2".to_string(),
-                                        read: BrwStatsBucketVals {
-                                            count: "0".to_string(),
-                                            pct: "0".to_string(),
-                                            cum_pct: "0".to_string(),
-                                        },
-                                        write: BrwStatsBucketVals {
-                                            count: "0".to_string(),
-                                            pct: "0".to_string(),
-                                            cum_pct: "11".to_string(),
-                                        },
+                                        name: 2,
+                                        read: 0,
+                                        write: 0,
                                     },
                                     BrwStatsBuckets {
-                                        name: "3".to_string(),
-                                        read: BrwStatsBucketVals {
-                                            count: "0".to_string(),
-                                            pct: "0".to_string(),
-                                            cum_pct: "0".to_string(),
-                                        },
-                                        write: BrwStatsBucketVals {
-                                            count: "0".to_string(),
-                                            pct: "0".to_string(),
-                                            cum_pct: "11".to_string(),
-                                        },
+                                        name: 3,
+                                        read: 0,
+                                        write: 0,
                                     },
                                     BrwStatsBuckets {
-                                        name: "4".to_string(),
-                                        read: BrwStatsBucketVals {
-                                            count: "0".to_string(),
-                                            pct: "0".to_string(),
-                                            cum_pct: "0".to_string(),
-                                        },
-                                        write: BrwStatsBucketVals {
-                                            count: "8".to_string(),
-                                            pct: "88".to_string(),
-                                            cum_pct: "100".to_string(),
-                                        },
+                                        name: 4,
+                                        read: 0,
+                                        write: 8,
                                     },
                                 ],
                             },
@@ -525,264 +418,104 @@ obdfilter.fs-OST0000.writethrough_cache_enable=1
                                 unit: "ios".to_string(),
                                 buckets: vec![
                                     BrwStatsBuckets {
-                                        name: "1".to_string(),
-                                        read: BrwStatsBucketVals {
-                                            count: "0".to_string(),
-                                            pct: "0".to_string(),
-                                            cum_pct: "0".to_string(),
-                                        },
-                                        write: BrwStatsBucketVals {
-                                            count: "2".to_string(),
-                                            pct: "6".to_string(),
-                                            cum_pct: "6".to_string(),
-                                        },
+                                        name: 1,
+                                        read: 0,
+                                        write: 2,
                                     },
                                     BrwStatsBuckets {
-                                        name: "2".to_string(),
-                                        read: BrwStatsBucketVals {
-                                            count: "0".to_string(),
-                                            pct: "0".to_string(),
-                                            cum_pct: "0".to_string(),
-                                        },
-                                        write: BrwStatsBucketVals {
-                                            count: "1".to_string(),
-                                            pct: "3".to_string(),
-                                            cum_pct: "9".to_string(),
-                                        },
+                                        name: 2,
+                                        read: 0,
+                                        write: 1,
                                     },
                                     BrwStatsBuckets {
-                                        name: "3".to_string(),
-                                        read: BrwStatsBucketVals {
-                                            count: "0".to_string(),
-                                            pct: "0".to_string(),
-                                            cum_pct: "0".to_string(),
-                                        },
-                                        write: BrwStatsBucketVals {
-                                            count: "1".to_string(),
-                                            pct: "3".to_string(),
-                                            cum_pct: "12".to_string(),
-                                        },
+                                        name: 3,
+                                        read: 0,
+                                        write: 1,
                                     },
                                     BrwStatsBuckets {
-                                        name: "4".to_string(),
-                                        read: BrwStatsBucketVals {
-                                            count: "0".to_string(),
-                                            pct: "0".to_string(),
-                                            cum_pct: "0".to_string(),
-                                        },
-                                        write: BrwStatsBucketVals {
-                                            count: "1".to_string(),
-                                            pct: "3".to_string(),
-                                            cum_pct: "15".to_string(),
-                                        },
+                                        name: 4,
+                                        read: 0,
+                                        write: 1,
                                     },
                                     BrwStatsBuckets {
-                                        name: "5".to_string(),
-                                        read: BrwStatsBucketVals {
-                                            count: "0".to_string(),
-                                            pct: "0".to_string(),
-                                            cum_pct: "0".to_string(),
-                                        },
-                                        write: BrwStatsBucketVals {
-                                            count: "3".to_string(),
-                                            pct: "9".to_string(),
-                                            cum_pct: "24".to_string(),
-                                        },
+                                        name: 5,
+                                        read: 0,
+                                        write: 3,
                                     },
                                     BrwStatsBuckets {
-                                        name: "6".to_string(),
-                                        read: BrwStatsBucketVals {
-                                            count: "0".to_string(),
-                                            pct: "0".to_string(),
-                                            cum_pct: "0".to_string(),
-                                        },
-                                        write: BrwStatsBucketVals {
-                                            count: "3".to_string(),
-                                            pct: "9".to_string(),
-                                            cum_pct: "33".to_string(),
-                                        },
+                                        name: 6,
+                                        read: 0,
+                                        write: 3,
                                     },
                                     BrwStatsBuckets {
-                                        name: "7".to_string(),
-                                        read: BrwStatsBucketVals {
-                                            count: "0".to_string(),
-                                            pct: "0".to_string(),
-                                            cum_pct: "0".to_string(),
-                                        },
-                                        write: BrwStatsBucketVals {
-                                            count: "3".to_string(),
-                                            pct: "9".to_string(),
-                                            cum_pct: "42".to_string(),
-                                        },
+                                        name: 7,
+                                        read: 0,
+                                        write: 3,
                                     },
                                     BrwStatsBuckets {
-                                        name: "8".to_string(),
-                                        read: BrwStatsBucketVals {
-                                            count: "0".to_string(),
-                                            pct: "0".to_string(),
-                                            cum_pct: "0".to_string(),
-                                        },
-                                        write: BrwStatsBucketVals {
-                                            count: "3".to_string(),
-                                            pct: "9".to_string(),
-                                            cum_pct: "51".to_string(),
-                                        },
+                                        name: 8,
+                                        read: 0,
+                                        write: 3,
                                     },
                                     BrwStatsBuckets {
-                                        name: "9".to_string(),
-                                        read: BrwStatsBucketVals {
-                                            count: "0".to_string(),
-                                            pct: "0".to_string(),
-                                            cum_pct: "0".to_string(),
-                                        },
-                                        write: BrwStatsBucketVals {
-                                            count: "1".to_string(),
-                                            pct: "3".to_string(),
-                                            cum_pct: "54".to_string(),
-                                        },
+                                        name: 9,
+                                        read: 0,
+                                        write: 1,
                                     },
                                     BrwStatsBuckets {
-                                        name: "10".to_string(),
-                                        read: BrwStatsBucketVals {
-                                            count: "0".to_string(),
-                                            pct: "0".to_string(),
-                                            cum_pct: "0".to_string(),
-                                        },
-                                        write: BrwStatsBucketVals {
-                                            count: "1".to_string(),
-                                            pct: "3".to_string(),
-                                            cum_pct: "57".to_string(),
-                                        },
+                                        name: 10,
+                                        read: 0,
+                                        write: 1,
                                     },
                                     BrwStatsBuckets {
-                                        name: "11".to_string(),
-                                        read: BrwStatsBucketVals {
-                                            count: "0".to_string(),
-                                            pct: "0".to_string(),
-                                            cum_pct: "0".to_string(),
-                                        },
-                                        write: BrwStatsBucketVals {
-                                            count: "1".to_string(),
-                                            pct: "3".to_string(),
-                                            cum_pct: "60".to_string(),
-                                        },
+                                        name: 11,
+                                        read: 0,
+                                        write: 1,
                                     },
                                     BrwStatsBuckets {
-                                        name: "12".to_string(),
-                                        read: BrwStatsBucketVals {
-                                            count: "0".to_string(),
-                                            pct: "0".to_string(),
-                                            cum_pct: "0".to_string(),
-                                        },
-                                        write: BrwStatsBucketVals {
-                                            count: "1".to_string(),
-                                            pct: "3".to_string(),
-                                            cum_pct: "63".to_string(),
-                                        },
+                                        name: 12,
+                                        read: 0,
+                                        write: 1,
                                     },
                                     BrwStatsBuckets {
-                                        name: "13".to_string(),
-                                        read: BrwStatsBucketVals {
-                                            count: "0".to_string(),
-                                            pct: "0".to_string(),
-                                            cum_pct: "0".to_string(),
-                                        },
-                                        write: BrwStatsBucketVals {
-                                            count: "2".to_string(),
-                                            pct: "6".to_string(),
-                                            cum_pct: "69".to_string(),
-                                        },
+                                        name: 13,
+                                        read: 0,
+                                        write: 2,
                                     },
                                     BrwStatsBuckets {
-                                        name: "14".to_string(),
-                                        read: BrwStatsBucketVals {
-                                            count: "0".to_string(),
-                                            pct: "0".to_string(),
-                                            cum_pct: "0".to_string(),
-                                        },
-                                        write: BrwStatsBucketVals {
-                                            count: "2".to_string(),
-                                            pct: "6".to_string(),
-                                            cum_pct: "75".to_string(),
-                                        },
+                                        name: 14,
+                                        read: 0,
+                                        write: 2,
                                     },
                                     BrwStatsBuckets {
-                                        name: "15".to_string(),
-                                        read: BrwStatsBucketVals {
-                                            count: "0".to_string(),
-                                            pct: "0".to_string(),
-                                            cum_pct: "0".to_string(),
-                                        },
-                                        write: BrwStatsBucketVals {
-                                            count: "2".to_string(),
-                                            pct: "6".to_string(),
-                                            cum_pct: "81".to_string(),
-                                        },
+                                        name: 15,
+                                        read: 0,
+                                        write: 2,
                                     },
                                     BrwStatsBuckets {
-                                        name: "16".to_string(),
-                                        read: BrwStatsBucketVals {
-                                            count: "0".to_string(),
-                                            pct: "0".to_string(),
-                                            cum_pct: "0".to_string(),
-                                        },
-                                        write: BrwStatsBucketVals {
-                                            count: "2".to_string(),
-                                            pct: "6".to_string(),
-                                            cum_pct: "87".to_string(),
-                                        },
+                                        name: 16,
+                                        read: 0,
+                                        write: 2,
                                     },
                                     BrwStatsBuckets {
-                                        name: "17".to_string(),
-                                        read: BrwStatsBucketVals {
-                                            count: "0".to_string(),
-                                            pct: "0".to_string(),
-                                            cum_pct: "0".to_string(),
-                                        },
-                                        write: BrwStatsBucketVals {
-                                            count: "1".to_string(),
-                                            pct: "3".to_string(),
-                                            cum_pct: "90".to_string(),
-                                        },
+                                        name: 17,
+                                        read: 0,
+                                        write: 1,
                                     },
                                     BrwStatsBuckets {
-                                        name: "18".to_string(),
-                                        read: BrwStatsBucketVals {
-                                            count: "0".to_string(),
-                                            pct: "0".to_string(),
-                                            cum_pct: "0".to_string(),
-                                        },
-                                        write: BrwStatsBucketVals {
-                                            count: "1".to_string(),
-                                            pct: "3".to_string(),
-                                            cum_pct: "93".to_string(),
-                                        },
+                                        name: 18,
+                                        read: 0,
+                                        write: 1,
                                     },
                                     BrwStatsBuckets {
-                                        name: "19".to_string(),
-                                        read: BrwStatsBucketVals {
-                                            count: "0".to_string(),
-                                            pct: "0".to_string(),
-                                            cum_pct: "0".to_string(),
-                                        },
-                                        write: BrwStatsBucketVals {
-                                            count: "1".to_string(),
-                                            pct: "3".to_string(),
-                                            cum_pct: "96".to_string(),
-                                        },
+                                        name: 19,
+                                        read: 0,
+                                        write: 1,
                                     },
                                     BrwStatsBuckets {
-                                        name: "20".to_string(),
-                                        read: BrwStatsBucketVals {
-                                            count: "0".to_string(),
-                                            pct: "0".to_string(),
-                                            cum_pct: "0".to_string(),
-                                        },
-                                        write: BrwStatsBucketVals {
-                                            count: "1".to_string(),
-                                            pct: "3".to_string(),
-                                            cum_pct: "100".to_string(),
-                                        },
+                                        name: 20,
+                                        read: 0,
+                                        write: 1,
                                     },
                                 ],
                             },
@@ -791,95 +524,39 @@ obdfilter.fs-OST0000.writethrough_cache_enable=1
                                 unit: "ios".to_string(),
                                 buckets: vec![
                                     BrwStatsBuckets {
-                                        name: "4".to_string(),
-                                        read: BrwStatsBucketVals {
-                                            count: "0".to_string(),
-                                            pct: "0".to_string(),
-                                            cum_pct: "0".to_string(),
-                                        },
-                                        write: BrwStatsBucketVals {
-                                            count: "1".to_string(),
-                                            pct: "11".to_string(),
-                                            cum_pct: "11".to_string(),
-                                        },
+                                        name: 4,
+                                        read: 0,
+                                        write: 1,
                                     },
                                     BrwStatsBuckets {
-                                        name: "8".to_string(),
-                                        read: BrwStatsBucketVals {
-                                            count: "0".to_string(),
-                                            pct: "0".to_string(),
-                                            cum_pct: "0".to_string(),
-                                        },
-                                        write: BrwStatsBucketVals {
-                                            count: "0".to_string(),
-                                            pct: "0".to_string(),
-                                            cum_pct: "11".to_string(),
-                                        },
+                                        name: 8,
+                                        read: 0,
+                                        write: 0,
                                     },
                                     BrwStatsBuckets {
-                                        name: "16".to_string(),
-                                        read: BrwStatsBucketVals {
-                                            count: "0".to_string(),
-                                            pct: "0".to_string(),
-                                            cum_pct: "0".to_string(),
-                                        },
-                                        write: BrwStatsBucketVals {
-                                            count: "0".to_string(),
-                                            pct: "0".to_string(),
-                                            cum_pct: "11".to_string(),
-                                        },
+                                        name: 16,
+                                        read: 0,
+                                        write: 0,
                                     },
                                     BrwStatsBuckets {
-                                        name: "32".to_string(),
-                                        read: BrwStatsBucketVals {
-                                            count: "0".to_string(),
-                                            pct: "0".to_string(),
-                                            cum_pct: "0".to_string(),
-                                        },
-                                        write: BrwStatsBucketVals {
-                                            count: "0".to_string(),
-                                            pct: "0".to_string(),
-                                            cum_pct: "11".to_string(),
-                                        },
+                                        name: 32,
+                                        read: 0,
+                                        write: 0,
                                     },
                                     BrwStatsBuckets {
-                                        name: "64".to_string(),
-                                        read: BrwStatsBucketVals {
-                                            count: "0".to_string(),
-                                            pct: "0".to_string(),
-                                            cum_pct: "0".to_string(),
-                                        },
-                                        write: BrwStatsBucketVals {
-                                            count: "0".to_string(),
-                                            pct: "0".to_string(),
-                                            cum_pct: "11".to_string(),
-                                        },
+                                        name: 64,
+                                        read: 0,
+                                        write: 0,
                                     },
                                     BrwStatsBuckets {
-                                        name: "128".to_string(),
-                                        read: BrwStatsBucketVals {
-                                            count: "0".to_string(),
-                                            pct: "0".to_string(),
-                                            cum_pct: "0".to_string(),
-                                        },
-                                        write: BrwStatsBucketVals {
-                                            count: "3".to_string(),
-                                            pct: "33".to_string(),
-                                            cum_pct: "44".to_string(),
-                                        },
+                                        name: 128,
+                                        read: 0,
+                                        write: 3,
                                     },
                                     BrwStatsBuckets {
-                                        name: "256".to_string(),
-                                        read: BrwStatsBucketVals {
-                                            count: "0".to_string(),
-                                            pct: "0".to_string(),
-                                            cum_pct: "0".to_string(),
-                                        },
-                                        write: BrwStatsBucketVals {
-                                            count: "5".to_string(),
-                                            pct: "55".to_string(),
-                                            cum_pct: "100".to_string(),
-                                        },
+                                        name: 256,
+                                        read: 0,
+                                        write: 5,
                                     },
                                 ],
                             },
@@ -888,56 +565,24 @@ obdfilter.fs-OST0000.writethrough_cache_enable=1
                                 unit: "ios".to_string(),
                                 buckets: vec![
                                     BrwStatsBuckets {
-                                        name: "128K".to_string(),
-                                        read: BrwStatsBucketVals {
-                                            count: "0".to_string(),
-                                            pct: "0".to_string(),
-                                            cum_pct: "0".to_string(),
-                                        },
-                                        write: BrwStatsBucketVals {
-                                            count: "1".to_string(),
-                                            pct: "3".to_string(),
-                                            cum_pct: "3".to_string(),
-                                        },
+                                        name: 131072,
+                                        read: 0,
+                                        write: 1,
                                     },
                                     BrwStatsBuckets {
-                                        name: "256K".to_string(),
-                                        read: BrwStatsBucketVals {
-                                            count: "0".to_string(),
-                                            pct: "0".to_string(),
-                                            cum_pct: "0".to_string(),
-                                        },
-                                        write: BrwStatsBucketVals {
-                                            count: "0".to_string(),
-                                            pct: "0".to_string(),
-                                            cum_pct: "3".to_string(),
-                                        },
+                                        name: 262144,
+                                        read: 0,
+                                        write: 0,
                                     },
                                     BrwStatsBuckets {
-                                        name: "512K".to_string(),
-                                        read: BrwStatsBucketVals {
-                                            count: "0".to_string(),
-                                            pct: "0".to_string(),
-                                            cum_pct: "0".to_string(),
-                                        },
-                                        write: BrwStatsBucketVals {
-                                            count: "0".to_string(),
-                                            pct: "0".to_string(),
-                                            cum_pct: "3".to_string(),
-                                        },
+                                        name: 524288,
+                                        read: 0,
+                                        write: 0,
                                     },
                                     BrwStatsBuckets {
-                                        name: "1M".to_string(),
-                                        read: BrwStatsBucketVals {
-                                            count: "0".to_string(),
-                                            pct: "0".to_string(),
-                                            cum_pct: "0".to_string(),
-                                        },
-                                        write: BrwStatsBucketVals {
-                                            count: "32".to_string(),
-                                            pct: "96".to_string(),
-                                            cum_pct: "100".to_string(),
-                                        },
+                                        name: 1048576,
+                                        read: 0,
+                                        write: 32,
                                     },
                                 ],
                             },


### PR DESCRIPTION
Use u64 for values and dump percent and cumulative percent as they can
be derived.

Signed-off-by: Joe Grund <jgrund@whamcloud.io>