### PR TITLE
Add parser for ldlm

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,7 +18,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "combine"
-version = "3.4.0"
+version = "3.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "ascii 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -62,12 +62,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 name = "lustre_collector"
 version = "0.1.0"
 dependencies = [
- "combine 3.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "combine 3.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "pretty_assertions 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.71 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.71 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.26 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_yaml 0.7.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_yaml 0.8.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -135,7 +135,7 @@ dependencies = [
 
 [[package]]
 name = "serde_yaml"
-version = "0.7.5"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "dtoa 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -203,7 +203,7 @@ dependencies = [
 "checksum ansi_term 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ee49baf6cb617b853aa8d93bf420db2383fab46d314482ca2803b40d5fde979b"
 "checksum ascii 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)" = "3ae7d751998c189c1d4468cf0a39bb2eae052a9c58d50ebb3b9591ee3813ad50"
 "checksum byteorder 1.2.4 (registry+https://github.com/rust-lang/crates.io-index)" = "8389c509ec62b9fe8eca58c502a0acaf017737355615243496cde4994f8fa4f9"
-"checksum combine 3.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "de4d970a671fc33c6ac45b4535c0723104c7cf9d7b09ede7c020c131f9b40f40"
+"checksum combine 3.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "7e67be864b6450c26fdb9242dee53a46fb9648d0b1a65521a6a1947b54fa011e"
 "checksum difference 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "524cbf6897b527295dff137cec09ecf3a05f4fddffd7dfcd1585403449e74198"
 "checksum dtoa 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)" = "6d301140eb411af13d3115f9a562c85cc6b541ade9dfa314132244aaee7489dd"
 "checksum either 1.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3be565ca5c557d7f59e7cfcf1844f9e3033650c929c6566f511e8005f205c1d0"
@@ -218,7 +218,7 @@ dependencies = [
 "checksum serde 1.0.71 (registry+https://github.com/rust-lang/crates.io-index)" = "6dfad05c8854584e5f72fb859385ecdfa03af69c3fd0572f0da2d4c95f060bdb"
 "checksum serde_derive 1.0.71 (registry+https://github.com/rust-lang/crates.io-index)" = "b719c6d5e9f73fbc37892246d5852333f040caa617b8873c6aced84bcb28e7bb"
 "checksum serde_json 1.0.26 (registry+https://github.com/rust-lang/crates.io-index)" = "44dd2cfde475037451fa99b7e5df77aa3cfd1536575fa8e7a538ab36dcde49ae"
-"checksum serde_yaml 0.7.5 (registry+https://github.com/rust-lang/crates.io-index)" = "ef8099d3df28273c99a1728190c7a9f19d444c941044f64adf986bee7ec53051"
+"checksum serde_yaml 0.8.3 (registry+https://github.com/rust-lang/crates.io-index)" = "46f14cb1eaa4ee296e6d9e0cc8ea96f772369d7b40987253772efbe2a63fd984"
 "checksum syn 0.14.8 (registry+https://github.com/rust-lang/crates.io-index)" = "b7bfcbb0c068d0f642a0ffbd5c604965a360a61f99e8add013cef23a838614f3"
 "checksum unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "fc72304796d0818e357ead4e000d19c9c174ab23dc11093ac919054d20a6a7fc"
 "checksum unreachable 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "382810877fe448991dfc7f0dd6e3ae5d58088fd0ea5e35189655f84e6814fa56"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,11 +4,11 @@ version = "0.1.0"
 authors = ["IML Team <iml@whamcloud.com>"]
 
 [dependencies]
-combine = "3.4.0"
+combine = "3.5.1"
 serde = "1.0"
 serde_derive = "1.0"
 serde_json = "1.0"
-serde_yaml = "0.7"
+serde_yaml = "0.8.3"
 
 [dev-dependencies]
 pretty_assertions = "0.5"

--- a/src/base_parsers.rs
+++ b/src/base_parsers.rs
@@ -5,13 +5,13 @@
 use combine::{
     char::{alpha_num, digit, newline, string},
     error::ParseError,
-    many1,
+    many1, one_of,
     parser::repeat::take_until,
     stream::Stream,
     token, try, unexpected, value, Parser,
 };
 
-use stats::Param;
+use stats::{Param, Target};
 
 pub fn period<I>() -> impl Parser<Input = I, Output = char>
 where
@@ -27,6 +27,15 @@ where
     I::Error: ParseError<I::Item, I::Range, I::Position>,
 {
     many1(alpha_num().or(token('_')))
+}
+
+/// Parses a target name
+pub fn target<I>() -> impl Parser<Input = I, Output = Target>
+where
+    I: Stream<Item = char>,
+    I::Error: ParseError<I::Item, I::Range, I::Position>,
+{
+    many1(alpha_num().or(one_of("_-".chars()))).map(Target)
 }
 
 /// Takes many consecutive digits and

--- a/src/oss/ldlm_parser.rs
+++ b/src/oss/ldlm_parser.rs
@@ -1,0 +1,214 @@
+// Copyright (c) 2018 DDN. All rights reserved.
+// Use of this source code is governed by a MIT-style
+// license that can be found in the LICENSE file.
+
+use combine::{
+    choice,
+    error::{ParseError, StreamError},
+    parser::char::{newline, string},
+    stream::{Stream, StreamErrorFor},
+    Parser,
+};
+
+use base_parsers::{digits, param, period, target};
+use stats::{Param, Record, Target, TargetStat, TargetStats};
+
+pub const CONTENDED_LOCKS: &str = "contended_locks";
+pub const CONTENTION_SECONDS: &str = "contention_seconds";
+pub const CTIME_AGE_LIMIT: &str = "ctime_age_limit";
+pub const EARLY_LOCK_CANCEL: &str = "early_lock_cancel";
+pub const LOCK_COUNT: &str = "lock_count";
+pub const LOCK_TIMEOUTS: &str = "lock_timeouts";
+pub const LOCK_UNUSED_COUNT: &str = "lock_unused_count";
+pub const LRU_MAX_AGE: &str = "lru_max_age";
+pub const LRU_SIZE: &str = "lru_size";
+pub const MAX_NOLOCK_BYTES: &str = "max_nolock_bytes";
+pub const MAX_PARALLEL_AST: &str = "max_parallel_ast";
+pub const RESOURCE_COUNT: &str = "resource_count";
+
+pub const LDLM_STATS: [&str; 12] = [
+    CONTENDED_LOCKS,
+    CONTENTION_SECONDS,
+    CTIME_AGE_LIMIT,
+    EARLY_LOCK_CANCEL,
+    LOCK_COUNT,
+    LOCK_TIMEOUTS,
+    LOCK_UNUSED_COUNT,
+    LRU_MAX_AGE,
+    LRU_SIZE,
+    MAX_NOLOCK_BYTES,
+    MAX_PARALLEL_AST,
+    RESOURCE_COUNT,
+];
+
+/// Takes LDLM_STATS and produces a list of params for
+/// consumption in proper ltcl get_param format.
+pub fn ldlm_params() -> Vec<String> {
+    LDLM_STATS
+        .into_iter()
+        .map(|x| format!("ldlm.namespaces.{{mdt-,filter-}}*.{}", x))
+        .collect::<Vec<String>>()
+}
+
+/// Parses the name of the target
+pub fn ldlm_target<I>() -> impl Parser<Input = I, Output = Target>
+where
+    I: Stream<Item = char>,
+    I::Error: ParseError<I::Item, I::Range, I::Position>,
+{
+    (
+        string("ldlm.namespaces."),
+        choice((string("mdt-"), string("filter-"))).with(target()),
+    ).and_then(|(_, Target(x))| {
+            let xs: Vec<&str> = x.split("_UUID").collect();
+
+            match xs.as_slice() {
+                [y, _] => Ok(Target(y.to_string())),
+                _ => Err(StreamErrorFor::<I>::expected_static_message("_UUID")),
+            }
+        })
+        .skip(period())
+        .message("while parsing lock_namespaces")
+}
+
+pub fn ldlm_stat<I>() -> impl Parser<Input = I, Output = (Param, u64)>
+where
+    I: Stream<Item = char>,
+    I::Error: ParseError<I::Item, I::Range, I::Position>,
+{
+    choice((
+        (param(CONTENDED_LOCKS), digits().skip(newline())),
+        (param(CONTENTION_SECONDS), digits().skip(newline())),
+        (param(CTIME_AGE_LIMIT), digits().skip(newline())),
+        (param(EARLY_LOCK_CANCEL), digits().skip(newline())),
+        (param(LOCK_COUNT), digits().skip(newline())),
+        (param(LOCK_TIMEOUTS), digits().skip(newline())),
+        (param(LOCK_UNUSED_COUNT), digits().skip(newline())),
+        (param(LRU_MAX_AGE), digits().skip(newline())),
+        (param(LRU_SIZE), digits().skip(newline())),
+        (param(MAX_NOLOCK_BYTES), digits().skip(newline())),
+        (param(MAX_PARALLEL_AST), digits().skip(newline())),
+        (param(RESOURCE_COUNT), digits().skip(newline())),
+    ))
+}
+
+pub fn parse<I>() -> impl Parser<Input = I, Output = Record>
+where
+    I: Stream<Item = char>,
+    I::Error: ParseError<I::Item, I::Range, I::Position>,
+{
+    (ldlm_target(), ldlm_stat())
+        .and_then(|(target, (Param(p), value))| match p.clone().as_ref() {
+            CONTENDED_LOCKS => Ok(TargetStats::ContendedLocks(TargetStat {
+                host: None,
+                target,
+                param: Param(p),
+                value,
+            })),
+            CONTENTION_SECONDS => Ok(TargetStats::ContentionSeconds(TargetStat {
+                host: None,
+                target,
+                param: Param(p),
+                value,
+            })),
+            CTIME_AGE_LIMIT => Ok(TargetStats::CtimeAgeLimit(TargetStat {
+                host: None,
+                target,
+                param: Param(p),
+                value,
+            })),
+            EARLY_LOCK_CANCEL => Ok(TargetStats::EarlyLockCancel(TargetStat {
+                host: None,
+                target,
+                param: Param(p),
+                value,
+            })),
+            LOCK_COUNT => Ok(TargetStats::LockCount(TargetStat {
+                host: None,
+                target,
+                param: Param(p),
+                value,
+            })),
+            LOCK_TIMEOUTS => Ok(TargetStats::LockTimeouts(TargetStat {
+                host: None,
+                target,
+                param: Param(p),
+                value,
+            })),
+            LOCK_UNUSED_COUNT => Ok(TargetStats::LockUnusedCount(TargetStat {
+                host: None,
+                target,
+                param: Param(p),
+                value,
+            })),
+            LRU_MAX_AGE => Ok(TargetStats::LruMaxAge(TargetStat {
+                host: None,
+                target,
+                param: Param(p),
+                value,
+            })),
+            LRU_SIZE => Ok(TargetStats::LruSize(TargetStat {
+                host: None,
+                target,
+                param: Param(p),
+                value,
+            })),
+            MAX_NOLOCK_BYTES => Ok(TargetStats::MaxNolockBytes(TargetStat {
+                host: None,
+                target,
+                param: Param(p),
+                value,
+            })),
+            MAX_PARALLEL_AST => Ok(TargetStats::MaxParallelAst(TargetStat {
+                host: None,
+                target,
+                param: Param(p),
+                value,
+            })),
+            RESOURCE_COUNT => Ok(TargetStats::ResourceCount(TargetStat {
+                host: None,
+                target,
+                param: Param(p),
+                value,
+            })),
+            _ => Err(StreamErrorFor::<I>::unexpected_static_message(
+                "Unexpected top-level param",
+            )),
+        })
+        .map(Record::Target)
+        .message("while parsing ldlm")
+}
+
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_ldlm_params() {
+        assert_eq!(
+            ldlm_params(),
+            vec![
+                "ldlm.namespaces.{mdt-,filter-}*.contended_locks".to_string(),
+                "ldlm.namespaces.{mdt-,filter-}*.contention_seconds".to_string(),
+                "ldlm.namespaces.{mdt-,filter-}*.ctime_age_limit".to_string(),
+                "ldlm.namespaces.{mdt-,filter-}*.early_lock_cancel".to_string(),
+                "ldlm.namespaces.{mdt-,filter-}*.lock_count".to_string(),
+                "ldlm.namespaces.{mdt-,filter-}*.lock_timeouts".to_string(),
+                "ldlm.namespaces.{mdt-,filter-}*.lock_unused_count".to_string(),
+                "ldlm.namespaces.{mdt-,filter-}*.lru_max_age".to_string(),
+                "ldlm.namespaces.{mdt-,filter-}*.lru_size".to_string(),
+                "ldlm.namespaces.{mdt-,filter-}*.max_nolock_bytes".to_string(),
+                "ldlm.namespaces.{mdt-,filter-}*.max_parallel_ast".to_string(),
+                "ldlm.namespaces.{mdt-,filter-}*.resource_count".to_string(),
+            ]
+        )
+    }
+
+    #[test]
+    fn test_lock_namespaces() {
+        let result = ldlm_stat().easy_parse("contended_locks=32\n");
+
+        let r = Ok(((Param(CONTENDED_LOCKS.to_string()), 32), ""));
+
+        assert_eq!(result, r);
+    }
+}

--- a/src/oss/ldlm_parser.rs
+++ b/src/oss/ldlm_parser.rs
@@ -179,6 +179,7 @@ where
         .message("while parsing ldlm")
 }
 
+#[cfg(test)]
 mod tests {
     use super::*;
 

--- a/src/oss/mod.rs
+++ b/src/oss/mod.rs
@@ -3,6 +3,7 @@
 // license that can be found in the LICENSE file.
 
 pub mod brw_stats_parser;
+pub mod ldlm_parser;
 pub mod obdfilter_parser;
 pub mod oss_parser;
 pub mod top_level_parser;

--- a/src/oss/obdfilter_parser.rs
+++ b/src/oss/obdfilter_parser.rs
@@ -2,14 +2,18 @@
 // Use of this source code is governed by a MIT-style
 // license that can be found in the LICENSE file.
 
+use combine::{
+    choice,
+    error::{ParseError, StreamError},
+    many1, one_of,
+    parser::char::{alpha_num, newline, string},
+    stream::{Stream, StreamErrorFor},
+    Parser,
+};
+
 use base_parsers::{digits, param, period, till_newline};
-use combine::error::ParseError;
-use combine::parser::char::{alpha_num, newline, string};
-use combine::parser::choice::choice;
-use combine::stream::Stream;
-use combine::{many1, one_of, Parser};
 use oss::brw_stats_parser::brw_stats;
-use stats::{ObdFilterStat, ObdFilterStats, Param, Target};
+use stats::{BrwStats, Param, Record, Stat, Target, TargetStat, TargetStats};
 use stats_parser::stats;
 
 pub const STATS: &str = "stats";
@@ -62,81 +66,175 @@ where
         .message("while parsing target_name")
 }
 
-fn obdfilter_stat<I>() -> impl Parser<Input = I, Output = (Param, ObdFilterStats)>
+#[derive(Debug)]
+enum ObdfilterStat {
+    Stats(Vec<Stat>),
+    BrwStats(Vec<BrwStats>),
+    /// Available inodes
+    FilesFree(u64),
+    /// Total inodes
+    FilesTotal(u64),
+    /// Type of target
+    FsType(String),
+    /// Available disk space
+    BytesAvail(u64),
+    /// Free disk space
+    BytesFree(u64),
+    /// Total disk space
+    BytesTotal(u64),
+    NumExports(u64),
+    TotDirty(u64),
+    TotGranted(u64),
+    TotPending(u64),
+}
+
+fn obdfilter_stat<I>() -> impl Parser<Input = I, Output = (Param, ObdfilterStat)>
 where
     I: Stream<Item = char>,
     I::Error: ParseError<I::Item, I::Range, I::Position>,
 {
     choice((
         // "job_stats",
-        (param(STATS), stats().map(ObdFilterStats::Stats)),
-        (param(BRW_STATS), brw_stats().map(ObdFilterStats::BrwStats)),
+        (param(STATS), stats().map(ObdfilterStat::Stats)),
+        (param(BRW_STATS), brw_stats().map(ObdfilterStat::BrwStats)),
         (
             param(FILES_FREE),
-            digits().skip(newline()).map(ObdFilterStats::FilesFree),
+            digits().skip(newline()).map(ObdfilterStat::FilesFree),
         ),
         (
             param(FILES_TOTAL),
-            digits().skip(newline()).map(ObdFilterStats::FilesTotal),
-        ),
-        (
-            param(FILES_TOTAL),
-            digits().skip(newline()).map(ObdFilterStats::FilesTotal),
+            digits().skip(newline()).map(ObdfilterStat::FilesTotal),
         ),
         (
             param(FS_TYPE),
-            till_newline().skip(newline()).map(ObdFilterStats::FsType),
+            till_newline().skip(newline()).map(ObdfilterStat::FsType),
         ),
         (
             param(KBYTES_AVAIL),
             digits()
                 .skip(newline())
-                .map(|x| ObdFilterStats::BytesAvail(x * 1024)),
+                .map(|x| x * 1024)
+                .map(ObdfilterStat::BytesAvail),
         ),
         (
             param(KBYTES_FREE),
             digits()
                 .skip(newline())
-                .map(|x| ObdFilterStats::BytesFree(x * 1024)),
+                .map(|x| x * 1024)
+                .map(ObdfilterStat::BytesFree),
         ),
         (
             param(KBYTES_TOTAL),
             digits()
                 .skip(newline())
-                .map(|x| ObdFilterStats::BytesTotal(x * 1024)),
+                .map(|x| x * 1024)
+                .map(ObdfilterStat::BytesTotal),
         ),
         (
             param(NUM_EXPORTS),
-            digits().skip(newline()).map(ObdFilterStats::NumExports),
+            digits().skip(newline()).map(ObdfilterStat::NumExports),
         ),
         (
             param(TOT_DIRTY),
-            digits().skip(newline()).map(ObdFilterStats::TotDirty),
+            digits().skip(newline()).map(ObdfilterStat::TotDirty),
         ),
         (
             param(TOT_GRANTED),
-            digits().skip(newline()).map(ObdFilterStats::TotGranted),
+            digits().skip(newline()).map(ObdfilterStat::TotGranted),
         ),
         (
             param(TOT_PENDING),
-            digits().skip(newline()).map(ObdFilterStats::TotPending),
+            digits().skip(newline()).map(ObdfilterStat::TotPending),
         ),
-    )).message("while getting obdfilter_stat")
+    )).message("while parsing obdfilter")
 }
 
-pub fn parse<I>() -> impl Parser<Input = I, Output = ObdFilterStat>
+pub fn parse<I>() -> impl Parser<Input = I, Output = Record>
 where
     I: Stream<Item = char>,
     I::Error: ParseError<I::Item, I::Range, I::Position>,
 {
+    #[cfg_attr(rustfmt, rustfmt_skip)]
     (target_name(), obdfilter_stat())
-        .map(|(target, (param, value))| ObdFilterStat {
-            host: None,
-            target,
-            param,
-            value,
-        })
-        .message("while parsing")
+        .and_then(|(target, (param, value))| {
+            #[allow(unreachable_patterns)]
+            match value {
+            ObdfilterStat::Stats(value) => Ok(TargetStats::Stats(TargetStat {
+                target,
+                host: None,
+                param,
+                value,
+            })),
+            ObdfilterStat::BrwStats(value) => Ok(TargetStats::BrwStats(TargetStat {
+                target,
+                host: None,
+                param,
+                value,
+            })),
+            ObdfilterStat::FilesFree(value) => Ok(TargetStats::FilesFree(TargetStat {
+                target,
+                host: None,
+                param,
+                value,
+            })),
+            ObdfilterStat::FilesTotal(value) => Ok(TargetStats::FilesTotal(TargetStat {
+                target,
+                host: None,
+                param,
+                value,
+            })),
+            ObdfilterStat::FsType(value) => Ok(TargetStats::FsType(TargetStat {
+                target,
+                host: None,
+                param,
+                value,
+            })),
+            ObdfilterStat::BytesAvail(value) => Ok(TargetStats::BytesAvail(TargetStat {
+                target,
+                host: None,
+                param,
+                value,
+            })),
+            ObdfilterStat::BytesFree(value) => Ok(TargetStats::BytesFree(TargetStat {
+                target,
+                host: None,
+                param,
+                value,
+            })),
+            ObdfilterStat::BytesTotal(value) => Ok(TargetStats::BytesTotal(TargetStat {
+                target,
+                host: None,
+                param,
+                value,
+            })),
+            ObdfilterStat::NumExports(value) => Ok(TargetStats::NumExports(TargetStat {
+                target,
+                host: None,
+                param,
+                value,
+            })),
+            ObdfilterStat::TotDirty(value) => Ok(TargetStats::TotDirty(TargetStat {
+                target,
+                host: None,
+                param,
+                value,
+            })),
+            ObdfilterStat::TotGranted(value) => Ok(TargetStats::TotGranted(TargetStat {
+                target,
+                host: None,
+                param,
+                value,
+            })),
+            ObdfilterStat::TotPending(value) => Ok(TargetStats::TotPending(TargetStat {
+                target,
+                host: None,
+                param,
+                value,
+            })),
+            _ => Err(StreamErrorFor::<I>::expected_static_message("_UUID")),
+        }})
+        .map(Record::Target)
+        .message("while parsing obdfilter")
 }
 
 #[cfg(test)]

--- a/src/oss/obdfilter_parser.rs
+++ b/src/oss/obdfilter_parser.rs
@@ -231,7 +231,7 @@ where
                 param,
                 value,
             })),
-            _ => Err(StreamErrorFor::<I>::expected_static_message("_UUID")),
+            _ => Err(StreamErrorFor::<I>::expected_static_message("ObdfilterStat Variant")),
         }})
         .map(Record::Target)
         .message("while parsing obdfilter")

--- a/src/oss/oss_parser.rs
+++ b/src/oss/oss_parser.rs
@@ -3,24 +3,26 @@
 // license that can be found in the LICENSE file.
 
 use combine::{choice, error::ParseError, many, Parser, Stream};
-use oss::{obdfilter_parser, top_level_parser};
-use stats::Stats;
+use oss::{ldlm_parser, obdfilter_parser, top_level_parser};
+use stats::Record;
 
 pub fn params() -> Vec<String> {
     let mut a = top_level_parser::top_level_params();
     a.extend(obdfilter_parser::obd_params());
+    a.extend(ldlm_parser::ldlm_params());
 
     a
 }
 
-pub fn parse<I>() -> impl Parser<Input = I, Output = Vec<Stats>>
+pub fn parse<I>() -> impl Parser<Input = I, Output = Vec<Record>>
 where
     I: Stream<Item = char>,
     I::Error: ParseError<I::Item, I::Range, I::Position>,
 {
     many(choice((
-        top_level_parser::parse().map(Stats::HostStats),
-        obdfilter_parser::parse().map(Stats::TargetStats),
+        top_level_parser::parse(),
+        obdfilter_parser::parse(),
+        ldlm_parser::parse(),
     )))
 }
 
@@ -30,8 +32,8 @@ mod tests {
     use super::*;
     use combine::stream::state::{SourcePosition, State};
     use stats::{
-        BrwStats, BrwStatsBucket, HostStat, HostStats, ObdFilterStat, ObdFilterStats, Param, Stat,
-        Stats, Target,
+        BrwStats, BrwStatsBucket, HostStat, HostStats, Param, Record, Stat, Target, TargetStat,
+        TargetStats,
     };
 
     #[test]
@@ -140,31 +142,31 @@ obdfilter.fs-OST0000.tot_pending=0
             result,
             Ok((
                 vec![
-                    Stats::HostStats(HostStats::MemUsed(HostStat {
+                    Record::Host(HostStats::Memused(HostStat {
                         host: None,
                         param: Param("memused".to_string()),
                         value: 77988429,
                     })),
-                    Stats::HostStats(HostStats::MemUsedMax(HostStat {
+                    Record::Host(HostStats::MemusedMax(HostStat {
                         host: None,
                         param: Param("memused_max".to_string()),
                         value: 77991501,
                     })),
-                    Stats::HostStats(HostStats::LNetMemUsed(HostStat {
+                    Record::Host(HostStats::LNetMemUsed(HostStat {
                         host: None,
                         param: Param("lnet_memused".to_string()),
                         value: 8082453,
                     })),
-                    Stats::HostStats(HostStats::Health(HostStat {
+                    Record::Host(HostStats::HealthCheck(HostStat {
                         host: None,
                         param: Param("health_check".to_string()),
                         value: "healthy".to_string(),
                     })),
-                    Stats::TargetStats(ObdFilterStat {
+                    Record::Target(TargetStats::Stats(TargetStat {
                         host: None,
                         param: Param("stats".to_string()),
                         target: Target("fs-OST0000".to_string()),
-                        value: ObdFilterStats::Stats(vec![
+                        value: vec![
                             Stat {
                                 name: "write_bytes".to_string(),
                                 units: "bytes".to_string(),
@@ -264,13 +266,13 @@ obdfilter.fs-OST0000.tot_pending=0
                                 sum: None,
                                 sumsquare: None,
                             },
-                        ]),
-                    }),
-                    Stats::TargetStats(ObdFilterStat {
+                        ],
+                    })),
+                    Record::Target(TargetStats::BrwStats(TargetStat {
                         host: None,
                         param: Param("brw_stats".to_string()),
                         target: Target("fs-OST0000".to_string()),
-                        value: ObdFilterStats::BrwStats(vec![
+                        value: vec![
                             BrwStats {
                                 name: "pages".to_string(),
                                 unit: "rpcs".to_string(),
@@ -531,68 +533,68 @@ obdfilter.fs-OST0000.tot_pending=0
                                     },
                                 ],
                             },
-                        ]),
-                    }),
-                    Stats::TargetStats(ObdFilterStat {
+                        ],
+                    })),
+                    Record::Target(TargetStats::FilesFree(TargetStat {
                         host: None,
                         param: Param("filesfree".to_string()),
                         target: Target("fs-OST0000".to_string()),
-                        value: ObdFilterStats::FilesFree(327382),
-                    }),
-                    Stats::TargetStats(ObdFilterStat {
+                        value: 327382,
+                    })),
+                    Record::Target(TargetStats::FilesTotal(TargetStat {
                         host: None,
                         param: Param("filestotal".to_string()),
                         target: Target("fs-OST0000".to_string()),
-                        value: ObdFilterStats::FilesTotal(327680),
-                    }),
-                    Stats::TargetStats(ObdFilterStat {
+                        value: 327680,
+                    })),
+                    Record::Target(TargetStats::FsType(TargetStat {
                         host: None,
                         param: Param("fstype".to_string()),
                         target: Target("fs-OST0000".to_string()),
-                        value: ObdFilterStats::FsType("osd-ldiskfs".to_string()),
-                    }),
-                    Stats::TargetStats(ObdFilterStat {
+                        value: "osd-ldiskfs".to_string(),
+                    })),
+                    Record::Target(TargetStats::BytesAvail(TargetStat {
                         host: None,
                         param: Param("kbytesavail".to_string()),
                         target: Target("fs-OST0000".to_string()),
-                        value: ObdFilterStats::BytesAvail(4594143232),
-                    }),
-                    Stats::TargetStats(ObdFilterStat {
+                        value: 4594143232,
+                    })),
+                    Record::Target(TargetStats::BytesFree(TargetStat {
                         host: None,
                         param: Param("kbytesfree".to_string()),
                         target: Target("fs-OST0000".to_string()),
-                        value: ObdFilterStats::BytesFree(4879355904),
-                    }),
-                    Stats::TargetStats(ObdFilterStat {
+                        value: 4879355904,
+                    })),
+                    Record::Target(TargetStats::BytesTotal(TargetStat {
                         host: None,
                         param: Param("kbytestotal".to_string()),
                         target: Target("fs-OST0000".to_string()),
-                        value: ObdFilterStats::BytesTotal(4947677184),
-                    }),
-                    Stats::TargetStats(ObdFilterStat {
+                        value: 4947677184,
+                    })),
+                    Record::Target(TargetStats::NumExports(TargetStat {
                         host: None,
                         param: Param("num_exports".to_string()),
                         target: Target("fs-OST0000".to_string()),
-                        value: ObdFilterStats::NumExports(2),
-                    }),
-                    Stats::TargetStats(ObdFilterStat {
+                        value: 2,
+                    })),
+                    Record::Target(TargetStats::TotDirty(TargetStat {
                         host: None,
                         param: Param("tot_dirty".to_string()),
                         target: Target("fs-OST0000".to_string()),
-                        value: ObdFilterStats::TotDirty(0),
-                    }),
-                    Stats::TargetStats(ObdFilterStat {
+                        value: 0,
+                    })),
+                    Record::Target(TargetStats::TotGranted(TargetStat {
                         host: None,
                         param: Param("tot_granted".to_string()),
                         target: Target("fs-OST0000".to_string()),
-                        value: ObdFilterStats::TotGranted(8666816),
-                    }),
-                    Stats::TargetStats(ObdFilterStat {
+                        value: 8666816,
+                    })),
+                    Record::Target(TargetStats::TotPending(TargetStat {
                         host: None,
                         param: Param("tot_pending".to_string()),
                         target: Target("fs-OST0000".to_string()),
-                        value: ObdFilterStats::TotPending(0),
-                    }),
+                        value: 0,
+                    })),
                 ],
                 State {
                     input: "",

--- a/src/stats.rs
+++ b/src/stats.rs
@@ -34,12 +34,12 @@ pub struct HostStat<T> {
 }
 
 #[derive(PartialEq, Debug, Serialize)]
-/// Stats collected via obdfilter.
-pub struct ObdFilterStat {
+/// Stats specific to a target.
+pub struct TargetStat<T> {
     pub host: Option<Host>,
     pub param: Param,
     pub target: Target,
-    pub value: ObdFilterStats,
+    pub value: T,
 }
 
 #[derive(PartialEq, Debug, Serialize)]
@@ -58,38 +58,50 @@ pub struct BrwStats {
 
 #[derive(PartialEq, Debug, Serialize)]
 pub enum HostStats {
-    MemUsedMax(HostStat<u64>),
-    MemUsed(HostStat<u64>),
+    MemusedMax(HostStat<u64>),
+    Memused(HostStat<u64>),
     LNetMemUsed(HostStat<u64>),
-    Health(HostStat<String>),
+    HealthCheck(HostStat<String>),
 }
 
-/// The obdfilter stats currently collected
+/// The target stats currently collected
 #[derive(PartialEq, Debug, Serialize)]
-pub enum ObdFilterStats {
+pub enum TargetStats {
     /// Operations per OST. Read and write data is particularly interesting
-    Stats(Vec<Stat>),
-    BrwStats(Vec<BrwStats>),
+    Stats(TargetStat<Vec<Stat>>),
+    BrwStats(TargetStat<Vec<BrwStats>>),
     /// Available inodes
-    FilesFree(u64),
+    FilesFree(TargetStat<u64>),
     /// Total inodes
-    FilesTotal(u64),
+    FilesTotal(TargetStat<u64>),
     /// Type of target
-    FsType(String),
+    FsType(TargetStat<String>),
     /// Available disk space
-    BytesAvail(u64),
+    BytesAvail(TargetStat<u64>),
     /// Free disk space
-    BytesFree(u64),
+    BytesFree(TargetStat<u64>),
     /// Total disk space
-    BytesTotal(u64),
-    NumExports(u64),
-    TotDirty(u64),
-    TotGranted(u64),
-    TotPending(u64),
+    BytesTotal(TargetStat<u64>),
+    NumExports(TargetStat<u64>),
+    TotDirty(TargetStat<u64>),
+    TotGranted(TargetStat<u64>),
+    TotPending(TargetStat<u64>),
+    ContendedLocks(TargetStat<u64>),
+    ContentionSeconds(TargetStat<u64>),
+    CtimeAgeLimit(TargetStat<u64>),
+    EarlyLockCancel(TargetStat<u64>),
+    LockCount(TargetStat<u64>),
+    LockTimeouts(TargetStat<u64>),
+    LockUnusedCount(TargetStat<u64>),
+    LruMaxAge(TargetStat<u64>),
+    LruSize(TargetStat<u64>),
+    MaxNolockBytes(TargetStat<u64>),
+    MaxParallelAst(TargetStat<u64>),
+    ResourceCount(TargetStat<u64>),
 }
 
 #[derive(PartialEq, Debug, Serialize)]
-pub enum Stats {
-    HostStats(HostStats),
-    TargetStats(ObdFilterStat),
+pub enum Record {
+    Host(HostStats),
+    Target(TargetStats),
 }


### PR DESCRIPTION
This patch adds a parser for many stats that match: `ldlm.namespaces.{mdt-,filter-}*`.

It also refactors the data structures into top-level `HostStats` and
`TargetStats` that reflect specific targets and hosts.

Signed-off-by: Joe Grund <jgrund@whamcloud.io>