### PR TITLE
Add arg parsing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12,9 +12,38 @@ version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "atty"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "libc 0.2.43 (registry+https://github.com/rust-lang/crates.io-index)",
+ "termion 1.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "bitflags"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "byteorder"
 version = "1.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "clap"
+version = "2.32.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "ansi_term 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "atty 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bitflags 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "strsim 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "textwrap 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "unicode-width 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "vec_map 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "combine"
@@ -44,6 +73,11 @@ version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "error-chain"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "itoa"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -62,7 +96,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 name = "lustre_collector"
 version = "0.1.0"
 dependencies = [
+ "clap 2.32.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "combine 3.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "error-chain 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "pretty_assertions 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.71 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.71 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -101,6 +137,19 @@ version = "0.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "proc-macro2 0.4.13 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "redox_syscall"
+version = "0.1.40"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "redox_termios"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "redox_syscall 0.1.40 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -145,6 +194,11 @@ dependencies = [
 ]
 
 [[package]]
+name = "strsim"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "syn"
 version = "0.14.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -153,6 +207,29 @@ dependencies = [
  "quote 0.6.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
+
+[[package]]
+name = "termion"
+version = "1.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "libc 0.2.43 (registry+https://github.com/rust-lang/crates.io-index)",
+ "redox_syscall 0.1.40 (registry+https://github.com/rust-lang/crates.io-index)",
+ "redox_termios 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "textwrap"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "unicode-width 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "unicode-width"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "unicode-xid"
@@ -166,6 +243,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "void 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
+
+[[package]]
+name = "vec_map"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "void"
@@ -202,11 +284,15 @@ dependencies = [
 [metadata]
 "checksum ansi_term 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ee49baf6cb617b853aa8d93bf420db2383fab46d314482ca2803b40d5fde979b"
 "checksum ascii 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)" = "3ae7d751998c189c1d4468cf0a39bb2eae052a9c58d50ebb3b9591ee3813ad50"
+"checksum atty 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)" = "9a7d5b8723950951411ee34d271d99dddcc2035a16ab25310ea2c8cfd4369652"
+"checksum bitflags 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "228047a76f468627ca71776ecdebd732a3423081fcf5125585bcd7c49886ce12"
 "checksum byteorder 1.2.4 (registry+https://github.com/rust-lang/crates.io-index)" = "8389c509ec62b9fe8eca58c502a0acaf017737355615243496cde4994f8fa4f9"
+"checksum clap 2.32.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b957d88f4b6a63b9d70d5f454ac8011819c6efa7727858f458ab71c756ce2d3e"
 "checksum combine 3.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "7e67be864b6450c26fdb9242dee53a46fb9648d0b1a65521a6a1947b54fa011e"
 "checksum difference 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "524cbf6897b527295dff137cec09ecf3a05f4fddffd7dfcd1585403449e74198"
 "checksum dtoa 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)" = "6d301140eb411af13d3115f9a562c85cc6b541ade9dfa314132244aaee7489dd"
 "checksum either 1.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3be565ca5c557d7f59e7cfcf1844f9e3033650c929c6566f511e8005f205c1d0"
+"checksum error-chain 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)" = "07e791d3be96241c77c43846b665ef1384606da2cd2a48730abe606a12906e02"
 "checksum itoa 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "5adb58558dcd1d786b5f0bd15f3226ee23486e24b7b58304b60f64dc68e62606"
 "checksum libc 0.2.43 (registry+https://github.com/rust-lang/crates.io-index)" = "76e3a3ef172f1a0b9a9ff0dd1491ae5e6c948b94479a3021819ba7d860c8645d"
 "checksum linked-hash-map 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "70fb39025bc7cdd76305867c4eccf2f2dcf6e9a57f5b21a93e1c2d86cd03ec9e"
@@ -214,14 +300,21 @@ dependencies = [
 "checksum pretty_assertions 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "3a029430f0d744bc3d15dd474d591bed2402b645d024583082b9f63bb936dac6"
 "checksum proc-macro2 0.4.13 (registry+https://github.com/rust-lang/crates.io-index)" = "ee5697238f0d893c7f0ecc59c0999f18d2af85e424de441178bcacc9f9e6cf67"
 "checksum quote 0.6.6 (registry+https://github.com/rust-lang/crates.io-index)" = "ed7d650913520df631972f21e104a4fa2f9c82a14afc65d17b388a2e29731e7c"
+"checksum redox_syscall 0.1.40 (registry+https://github.com/rust-lang/crates.io-index)" = "c214e91d3ecf43e9a4e41e578973adeb14b474f2bee858742d127af75a0112b1"
+"checksum redox_termios 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "7e891cfe48e9100a70a3b6eb652fef28920c117d366339687bd5576160db0f76"
 "checksum ryu 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "16aa12da69951804cddf5f74d96abcc414a31b064e610dc81e37c1536082f491"
 "checksum serde 1.0.71 (registry+https://github.com/rust-lang/crates.io-index)" = "6dfad05c8854584e5f72fb859385ecdfa03af69c3fd0572f0da2d4c95f060bdb"
 "checksum serde_derive 1.0.71 (registry+https://github.com/rust-lang/crates.io-index)" = "b719c6d5e9f73fbc37892246d5852333f040caa617b8873c6aced84bcb28e7bb"
 "checksum serde_json 1.0.26 (registry+https://github.com/rust-lang/crates.io-index)" = "44dd2cfde475037451fa99b7e5df77aa3cfd1536575fa8e7a538ab36dcde49ae"
 "checksum serde_yaml 0.8.3 (registry+https://github.com/rust-lang/crates.io-index)" = "46f14cb1eaa4ee296e6d9e0cc8ea96f772369d7b40987253772efbe2a63fd984"
+"checksum strsim 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "bb4f380125926a99e52bc279241539c018323fab05ad6368b56f93d9369ff550"
 "checksum syn 0.14.8 (registry+https://github.com/rust-lang/crates.io-index)" = "b7bfcbb0c068d0f642a0ffbd5c604965a360a61f99e8add013cef23a838614f3"
+"checksum termion 1.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "689a3bdfaab439fd92bc87df5c4c78417d3cbe537487274e9b0b2dce76e92096"
+"checksum textwrap 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)" = "307686869c93e71f94da64286f9a9524c0f308a9e1c87a583de8e9c9039ad3f6"
+"checksum unicode-width 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "882386231c45df4700b275c7ff55b6f3698780a650026380e72dabe76fa46526"
 "checksum unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "fc72304796d0818e357ead4e000d19c9c174ab23dc11093ac919054d20a6a7fc"
 "checksum unreachable 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "382810877fe448991dfc7f0dd6e3ae5d58088fd0ea5e35189655f84e6814fa56"
+"checksum vec_map 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)" = "05c78687fb1a80548ae3250346c3db86a80a7cdd77bda190189f2d0a0987c81a"
 "checksum void 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"
 "checksum winapi 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)" = "773ef9dcc5f24b7d850d0ff101e542ff24c3b090a9768e03ff889fdef41f00fd"
 "checksum winapi-i686-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,11 @@ serde = "1.0"
 serde_derive = "1.0"
 serde_json = "1.0"
 serde_yaml = "0.8.3"
+clap = "2.32.0"
+
+[dependencies.error-chain]
+version = "0.12.0"
+default-features = false
 
 [dev-dependencies]
 pretty_assertions = "0.5"

--- a/README.md
+++ b/README.md
@@ -13,5 +13,5 @@ It is provided as a standalone binary that can be called to retrieve stats in th
 lustre_collector
 
 # Will return stats in YAML format
-lustre_collector --format=Yaml
+lustre_collector --format=yaml
 ```

--- a/README.md
+++ b/README.md
@@ -2,19 +2,16 @@
 
 [![Build Status](https://travis-ci.com/whamcloud/lustre-collector.svg?branch=master)](https://travis-ci.com/whamcloud/lustre-collector)
 
-This repo provides data fetching and extraction capabilities for Lustre statisics.
+This repo provides a parsed representation of common Lustre statistics.
 
-It is provided as a standalone binary that can be called to retrieve stats in the desired output.
+It is provided as a standalone binary that can be called to retrieve stats in the desired output (Currently either JSON | YAML).
 
 ## Usage
 
 ```bash
-# Will return OST related stats in JSON format
-lustre_collector --host=oss1.domain --target_type=oss
+# Will return stats in JSON format
+lustre_collector
 
-# Will return OST related stats in YAML format
-lustre_collector --host=oss1.domain --target_type=oss --format=yaml
-
-# Will return MGS related stats in YAML format
-lustre_collector --host=oss1.domain --target_type=mgs
+# Will return stats in YAML format
+lustre_collector --format=Yaml
 ```

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,10 +4,18 @@
 
 #![allow(unknown_lints)]
 #![warn(clippy)]
+// `error_chain!` can recurse deeply
+#![recursion_limit = "1024"]
 
 #[cfg(test)]
 #[macro_use]
 extern crate pretty_assertions;
+
+#[macro_use]
+extern crate error_chain;
+
+#[macro_use]
+extern crate clap;
 
 #[macro_use]
 extern crate serde_derive;
@@ -16,6 +24,8 @@ extern crate combine;
 extern crate serde;
 extern crate serde_json;
 extern crate serde_yaml;
+
+use clap::{App, Arg};
 
 use combine::stream::state::State;
 use combine::Parser;
@@ -31,24 +41,77 @@ use oss::oss_parser;
 
 use std::process::Command;
 
+mod errors {
+    // Create the Error, ErrorKind, ResultExt, and Result types
+    error_chain!{}
+}
+
+use errors::*;
+
+arg_enum!{
+    #[derive(PartialEq, Debug)]
+    enum Format {
+        Json,
+        Yaml
+    }
+}
+
 fn main() {
-    // let host = env::var("HOSTNAME").expect("HOSTNAME env var must be supplied to lustre_collector");
+    let variants = &Format::variants()
+        .iter()
+        .map(|x| x.to_ascii_lowercase())
+        .collect::<Vec<_>>();
+
+    let matches = App::new("lustre_collector")
+        .version("0.1.0")
+        .author("IML Team")
+        .about("Grabs various Lustre statistics for display in JSON or YAML")
+        .arg(
+            Arg::with_name("format")
+                .short("f")
+                .long("format")
+                .possible_values(&variants.iter().map(|x| x.as_str()).collect::<Vec<_>>()[..])
+                .default_value(&variants.iter().nth(0).unwrap())
+                .help("Sets the output formatting")
+                .takes_value(true),
+        )
+        .get_matches();
+
+    let format = value_t!(matches, "format", Format).unwrap_or_else(|e| e.exit());
 
     let output = Command::new("lctl")
         .arg("get_param")
         .args(oss_parser::params())
         .output()
-        .expect("failed to get obdfilter stats");
+        .expect("failed to get lctl stats");
 
     let stats = str::from_utf8(&output.stdout).unwrap();
 
     let parsed = oss_parser::parse().easy_parse(State::new(stats));
 
-    println!("{}", stats);
+    let r = match format {
+        Format::Json => {
+            serde_json::to_string(&parsed.unwrap().0).chain_err(|| "serializing to JSON")
+        }
+        Format::Yaml => {
+            serde_yaml::to_string(&parsed.unwrap().0).chain_err(|| "serializing to YAML")
+        }
+    };
 
-    println!("{:#?}", &parsed);
+    match r {
+        Ok(x) => println!("{}", x),
+        Err(ref e) => {
+            println!("error: {}", e);
 
-    println!("{:?}", serde_json::to_string(&parsed.unwrap().0));
+            for e in e.iter().skip(1) {
+                println!("caused by: {}", e);
+            }
 
-    // println!("{:?}", serde_yaml::to_string(&parsed));
+            if let Some(backtrace) = e.backtrace() {
+                println!("backtrace: {:?}", backtrace);
+            }
+
+            ::std::process::exit(1);
+        }
+    }
 }

--- a/src/oss/ldlm_parser.rs
+++ b/src/oss/ldlm_parser.rs
@@ -100,73 +100,61 @@ where
     (ldlm_target(), ldlm_stat())
         .and_then(|(target, (Param(p), value))| match p.clone().as_ref() {
             CONTENDED_LOCKS => Ok(TargetStats::ContendedLocks(TargetStat {
-                host: None,
                 target,
                 param: Param(p),
                 value,
             })),
             CONTENTION_SECONDS => Ok(TargetStats::ContentionSeconds(TargetStat {
-                host: None,
                 target,
                 param: Param(p),
                 value,
             })),
             CTIME_AGE_LIMIT => Ok(TargetStats::CtimeAgeLimit(TargetStat {
-                host: None,
                 target,
                 param: Param(p),
                 value,
             })),
             EARLY_LOCK_CANCEL => Ok(TargetStats::EarlyLockCancel(TargetStat {
-                host: None,
                 target,
                 param: Param(p),
                 value,
             })),
             LOCK_COUNT => Ok(TargetStats::LockCount(TargetStat {
-                host: None,
                 target,
                 param: Param(p),
                 value,
             })),
             LOCK_TIMEOUTS => Ok(TargetStats::LockTimeouts(TargetStat {
-                host: None,
                 target,
                 param: Param(p),
                 value,
             })),
             LOCK_UNUSED_COUNT => Ok(TargetStats::LockUnusedCount(TargetStat {
-                host: None,
                 target,
                 param: Param(p),
                 value,
             })),
             LRU_MAX_AGE => Ok(TargetStats::LruMaxAge(TargetStat {
-                host: None,
                 target,
                 param: Param(p),
                 value,
             })),
             LRU_SIZE => Ok(TargetStats::LruSize(TargetStat {
-                host: None,
                 target,
                 param: Param(p),
                 value,
             })),
             MAX_NOLOCK_BYTES => Ok(TargetStats::MaxNolockBytes(TargetStat {
-                host: None,
                 target,
                 param: Param(p),
                 value,
             })),
             MAX_PARALLEL_AST => Ok(TargetStats::MaxParallelAst(TargetStat {
-                host: None,
                 target,
                 param: Param(p),
                 value,
             })),
             RESOURCE_COUNT => Ok(TargetStats::ResourceCount(TargetStat {
-                host: None,
                 target,
                 param: Param(p),
                 value,

--- a/src/oss/obdfilter_parser.rs
+++ b/src/oss/obdfilter_parser.rs
@@ -200,8 +200,7 @@ where
                 value,
             })),
             ObdfilterStat::NumExports(value) => Ok(TargetStats::NumExports(TargetStat {
-                target,
-                
+                target,                
                 param,
                 value,
             })),

--- a/src/oss/obdfilter_parser.rs
+++ b/src/oss/obdfilter_parser.rs
@@ -161,73 +161,62 @@ where
             match value {
             ObdfilterStat::Stats(value) => Ok(TargetStats::Stats(TargetStat {
                 target,
-                host: None,
                 param,
                 value,
             })),
             ObdfilterStat::BrwStats(value) => Ok(TargetStats::BrwStats(TargetStat {
                 target,
-                host: None,
                 param,
                 value,
             })),
             ObdfilterStat::FilesFree(value) => Ok(TargetStats::FilesFree(TargetStat {
                 target,
-                host: None,
                 param,
                 value,
             })),
             ObdfilterStat::FilesTotal(value) => Ok(TargetStats::FilesTotal(TargetStat {
                 target,
-                host: None,
                 param,
                 value,
             })),
             ObdfilterStat::FsType(value) => Ok(TargetStats::FsType(TargetStat {
                 target,
-                host: None,
                 param,
                 value,
             })),
             ObdfilterStat::BytesAvail(value) => Ok(TargetStats::BytesAvail(TargetStat {
                 target,
-                host: None,
                 param,
                 value,
             })),
             ObdfilterStat::BytesFree(value) => Ok(TargetStats::BytesFree(TargetStat {
                 target,
-                host: None,
                 param,
                 value,
             })),
             ObdfilterStat::BytesTotal(value) => Ok(TargetStats::BytesTotal(TargetStat {
                 target,
-                host: None,
                 param,
                 value,
             })),
             ObdfilterStat::NumExports(value) => Ok(TargetStats::NumExports(TargetStat {
                 target,
-                host: None,
+                
                 param,
                 value,
             })),
             ObdfilterStat::TotDirty(value) => Ok(TargetStats::TotDirty(TargetStat {
                 target,
-                host: None,
                 param,
                 value,
             })),
             ObdfilterStat::TotGranted(value) => Ok(TargetStats::TotGranted(TargetStat {
                 target,
-                host: None,
                 param,
                 value,
             })),
             ObdfilterStat::TotPending(value) => Ok(TargetStats::TotPending(TargetStat {
                 target,
-                host: None,
                 param,
                 value,
             })),

--- a/src/oss/oss_parser.rs
+++ b/src/oss/oss_parser.rs
@@ -143,27 +143,22 @@ obdfilter.fs-OST0000.tot_pending=0
             Ok((
                 vec![
                     Record::Host(HostStats::Memused(HostStat {
-                        host: None,
                         param: Param("memused".to_string()),
                         value: 77988429,
                     })),
                     Record::Host(HostStats::MemusedMax(HostStat {
-                        host: None,
                         param: Param("memused_max".to_string()),
                         value: 77991501,
                     })),
                     Record::Host(HostStats::LNetMemUsed(HostStat {
-                        host: None,
                         param: Param("lnet_memused".to_string()),
                         value: 8082453,
                     })),
                     Record::Host(HostStats::HealthCheck(HostStat {
-                        host: None,
                         param: Param("health_check".to_string()),
                         value: "healthy".to_string(),
                     })),
                     Record::Target(TargetStats::Stats(TargetStat {
-                        host: None,
                         param: Param("stats".to_string()),
                         target: Target("fs-OST0000".to_string()),
                         value: vec![
@@ -269,7 +264,6 @@ obdfilter.fs-OST0000.tot_pending=0
                         ],
                     })),
                     Record::Target(TargetStats::BrwStats(TargetStat {
-                        host: None,
                         param: Param("brw_stats".to_string()),
                         target: Target("fs-OST0000".to_string()),
                         value: vec![
@@ -536,61 +530,51 @@ obdfilter.fs-OST0000.tot_pending=0
                         ],
                     })),
                     Record::Target(TargetStats::FilesFree(TargetStat {
-                        host: None,
                         param: Param("filesfree".to_string()),
                         target: Target("fs-OST0000".to_string()),
                         value: 327382,
                     })),
                     Record::Target(TargetStats::FilesTotal(TargetStat {
-                        host: None,
                         param: Param("filestotal".to_string()),
                         target: Target("fs-OST0000".to_string()),
                         value: 327680,
                     })),
                     Record::Target(TargetStats::FsType(TargetStat {
-                        host: None,
                         param: Param("fstype".to_string()),
                         target: Target("fs-OST0000".to_string()),
                         value: "osd-ldiskfs".to_string(),
                     })),
                     Record::Target(TargetStats::BytesAvail(TargetStat {
-                        host: None,
                         param: Param("kbytesavail".to_string()),
                         target: Target("fs-OST0000".to_string()),
                         value: 4594143232,
                     })),
                     Record::Target(TargetStats::BytesFree(TargetStat {
-                        host: None,
                         param: Param("kbytesfree".to_string()),
                         target: Target("fs-OST0000".to_string()),
                         value: 4879355904,
                     })),
                     Record::Target(TargetStats::BytesTotal(TargetStat {
-                        host: None,
                         param: Param("kbytestotal".to_string()),
                         target: Target("fs-OST0000".to_string()),
                         value: 4947677184,
                     })),
                     Record::Target(TargetStats::NumExports(TargetStat {
-                        host: None,
                         param: Param("num_exports".to_string()),
                         target: Target("fs-OST0000".to_string()),
                         value: 2,
                     })),
                     Record::Target(TargetStats::TotDirty(TargetStat {
-                        host: None,
                         param: Param("tot_dirty".to_string()),
                         target: Target("fs-OST0000".to_string()),
                         value: 0,
                     })),
                     Record::Target(TargetStats::TotGranted(TargetStat {
-                        host: None,
                         param: Param("tot_granted".to_string()),
                         target: Target("fs-OST0000".to_string()),
                         value: 8666816,
                     })),
                     Record::Target(TargetStats::TotPending(TargetStat {
-                        host: None,
                         param: Param("tot_pending".to_string()),
                         target: Target("fs-OST0000".to_string()),
                         value: 0,

--- a/src/oss/top_level_parser.rs
+++ b/src/oss/top_level_parser.rs
@@ -58,22 +58,18 @@ where
             #[allow(unreachable_patterns)]
             match v {
                 TopLevelStat::Memused(value) => Ok(HostStats::Memused(HostStat {
-                    host: None,
                     param,
                     value,
                 })),
                 TopLevelStat::MemusedMax(value) => Ok(HostStats::MemusedMax(HostStat {
-                    host: None,
                     param,
                     value,
                 })),
                 TopLevelStat::LnetMemused(value) => Ok(HostStats::LNetMemUsed(HostStat {
-                    host: None,
                     param,
                     value,
                 })),
                 TopLevelStat::HealthCheck(value) => Ok(HostStats::HealthCheck(HostStat {
-                    host: None,
                     param,
                     value,
                 })),
@@ -114,7 +110,6 @@ mod tests {
             result,
             Ok((
                 Record::Host(HostStats::MemusedMax(HostStat {
-                    host: None,
                     param: Param(MEMUSED_MAX.to_string()),
                     value: 77991501
                 })),

--- a/src/stats.rs
+++ b/src/stats.rs
@@ -28,7 +28,6 @@ pub struct Stat {
 #[derive(PartialEq, Debug, Serialize)]
 /// A Stat specific to a host.
 pub struct HostStat<T> {
-    pub host: Option<Host>,
     pub param: Param,
     pub value: T,
 }
@@ -36,7 +35,6 @@ pub struct HostStat<T> {
 #[derive(PartialEq, Debug, Serialize)]
 /// Stats specific to a target.
 pub struct TargetStat<T> {
-    pub host: Option<Host>,
     pub param: Param,
     pub target: Target,
     pub value: T,
@@ -57,6 +55,7 @@ pub struct BrwStats {
 }
 
 #[derive(PartialEq, Debug, Serialize)]
+#[serde(untagged)]
 pub enum HostStats {
     MemusedMax(HostStat<u64>),
     Memused(HostStat<u64>),
@@ -66,6 +65,7 @@ pub enum HostStats {
 
 /// The target stats currently collected
 #[derive(PartialEq, Debug, Serialize)]
+#[serde(untagged)]
 pub enum TargetStats {
     /// Operations per OST. Read and write data is particularly interesting
     Stats(TargetStat<Vec<Stat>>),
@@ -101,6 +101,7 @@ pub enum TargetStats {
 }
 
 #[derive(PartialEq, Debug, Serialize)]
+#[serde(untagged)]
 pub enum Record {
     Host(HostStats),
     Target(TargetStats),


### PR DESCRIPTION
This patch adds arg parsing using `clap`.

Initially, this adds support for a format flag to output in either JSON
or YAML.

In addition, this patch removes the host field, as that should be
derived if needed in a post retrieval step.

Signed-off-by: Joe Grund <jgrund@whamcloud.io>