### PR TITLE
Add parsers for MGTs

### DIFF
--- a/src/base_parsers.rs
+++ b/src/base_parsers.rs
@@ -11,7 +11,7 @@ use combine::{
     token, try, unexpected, value, Parser,
 };
 
-use stats::{Param, Target};
+use types::{Param, Target};
 
 pub fn period<I>() -> impl Parser<Input = I, Output = char>
 where
@@ -64,17 +64,19 @@ where
     string(x).map(move |_| String::from(y))
 }
 
-pub fn not_word<I>(x: &'static str) -> impl Parser<Input = I, Output = String>
+pub fn not_words<I>(xs: &'static [&'static str]) -> impl Parser<Input = I, Output = String>
 where
     I: Stream<Item = char>,
     I::Error: ParseError<I::Item, I::Range, I::Position>,
 {
     try(word().then(move |y| {
-        if x == y {
-            unexpected(x).map(|_| "".to_string()).right()
-        } else {
-            value(y.to_string()).left()
+        for &x in xs {
+            if x.to_string() == y {
+                return unexpected(x).map(|_| "".to_string()).right();
+            }
         }
+
+        value(y.to_string()).left()
     }))
 }
 
@@ -92,7 +94,7 @@ where
 mod tests {
     use super::*;
     use combine::stream::state::{SourcePosition, State};
-    use stats::Param;
+    use types::Param;
 
     #[test]
     fn test_param() {

--- a/src/mgs/mgs_parser.rs
+++ b/src/mgs/mgs_parser.rs
@@ -1,0 +1,121 @@
+// Copyright (c) 2018 DDN. All rights reserved.
+// Use of this source code is governed by a MIT-style
+// license that can be found in the LICENSE file.
+
+use base_parsers::{digits, param, period, target};
+use stats_parser::stats;
+use types::{Param, Record, Stat, Target, TargetStat, TargetStats, TargetVariant};
+
+use combine::{
+    choice,
+    error::{ParseError, StreamError},
+    parser::char::{newline, string},
+    stream::{Stream, StreamErrorFor},
+    try, Parser,
+};
+
+pub const STATS: &str = "stats";
+pub const THREADS_MIN: &str = "threads_min";
+pub const THREADS_MAX: &str = "threads_max";
+pub const NUM_EXPORTS: &str = "num_exports";
+
+pub fn params() -> Vec<String> {
+    [
+        format!("mgs.*.mgs.{}", STATS),
+        format!("mgs.*.mgs.{}", THREADS_MAX),
+        format!("mgs.*.mgs.{}", THREADS_MIN),
+        format!("mgs.*.{}", NUM_EXPORTS),
+    ].into_iter()
+        .map(|x| x.to_owned())
+        .collect::<Vec<_>>()
+}
+
+#[derive(Debug)]
+enum MgsStat {
+    Stats(Vec<Stat>),
+    ThreadsMin(u64),
+    ThreadsMax(u64),
+    NumExports(u64),
+}
+
+/// Parses the name of a target
+fn target_name<I>() -> impl Parser<Input = I, Output = Target>
+where
+    I: Stream<Item = char>,
+    I::Error: ParseError<I::Item, I::Range, I::Position>,
+{
+    (try(string("mgs")).skip(period()), target().skip(period()))
+        .map(|(_, x)| x)
+        .message("while parsing target_name")
+}
+
+fn mgs_stat<I>() -> impl Parser<Input = I, Output = (Param, MgsStat)>
+where
+    I: Stream<Item = char>,
+    I::Error: ParseError<I::Item, I::Range, I::Position>,
+{
+    choice((
+        (
+            param(NUM_EXPORTS),
+            digits().skip(newline()).map(MgsStat::NumExports),
+        ),
+        (
+            string("mgs").skip(period()),
+            choice((
+                (param(STATS), stats().map(MgsStat::Stats)),
+                (
+                    param(THREADS_MIN),
+                    digits().skip(newline()).map(MgsStat::ThreadsMin),
+                ),
+                (
+                    param(THREADS_MAX),
+                    digits().skip(newline()).map(MgsStat::ThreadsMax),
+                ),
+            )),
+        ).map(|(_, (y, z))| (y, z)),
+    ))
+}
+
+pub fn parse<I>() -> impl Parser<Input = I, Output = Record>
+where
+    I: Stream<Item = char>,
+    I::Error: ParseError<I::Item, I::Range, I::Position>,
+{
+    (target_name(), mgs_stat())
+        .and_then(|(target, (param, value))| {
+            #[allow(unreachable_patterns)]
+            let r = match value {
+                MgsStat::Stats(value) => Ok(TargetStats::Stats(TargetStat {
+                    kind: TargetVariant::MGT,
+                    target,
+                    param,
+                    value,
+                })),
+                MgsStat::NumExports(value) => Ok(TargetStats::NumExports(TargetStat {
+                    kind: TargetVariant::MGT,
+                    target,
+                    param,
+                    value,
+                })),
+                MgsStat::ThreadsMin(value) => Ok(TargetStats::ThreadsMin(TargetStat {
+                    kind: TargetVariant::MGT,
+                    target,
+                    param,
+                    value,
+                })),
+                MgsStat::ThreadsMax(value) => Ok(TargetStats::ThreadsMax(TargetStat {
+                    kind: TargetVariant::MGT,
+                    target,
+                    param,
+                    value,
+                })),
+                _ => Err(StreamErrorFor::<I>::expected_static_message(
+                    "MgsStat Variant",
+                )),
+            };
+
+            r
+        })
+        .map(Record::Target)
+        .message("while parsing mgs params")
+}

--- a/src/mgs/mod.rs
+++ b/src/mgs/mod.rs
@@ -2,7 +2,4 @@
 // Use of this source code is governed by a MIT-style
 // license that can be found in the LICENSE file.
 
-pub mod brw_stats_parser;
-pub mod ldlm_parser;
-pub mod obdfilter_parser;
-pub mod oss_parser;
+pub mod mgs_parser;

--- a/src/oss/brw_stats_parser.rs
+++ b/src/oss/brw_stats_parser.rs
@@ -8,7 +8,7 @@ use combine::parser::char::{newline, spaces, string};
 use combine::stream::Stream;
 use combine::{choice, many, many1, one_of, optional, token, try, Parser};
 use snapshot_time::snapshot_time;
-use stats::{BrwStats, BrwStatsBucket};
+use types::{BrwStats, BrwStatsBucket};
 
 fn human_to_bytes((x, y): (u64, Option<char>)) -> u64 {
     let mult = match y {

--- a/src/oss/ldlm_parser.rs
+++ b/src/oss/ldlm_parser.rs
@@ -11,7 +11,7 @@ use combine::{
 };
 
 use base_parsers::{digits, param, period, target};
-use stats::{Param, Record, Target, TargetStat, TargetStats};
+use types::{Param, Record, Target, TargetStat, TargetStats, TargetVariant};
 
 pub const CONTENDED_LOCKS: &str = "contended_locks";
 pub const CONTENTION_SECONDS: &str = "contention_seconds";
@@ -100,61 +100,73 @@ where
     (ldlm_target(), ldlm_stat())
         .and_then(|(target, (Param(p), value))| match p.clone().as_ref() {
             CONTENDED_LOCKS => Ok(TargetStats::ContendedLocks(TargetStat {
+                kind: TargetVariant::OST,
                 target,
                 param: Param(p),
                 value,
             })),
             CONTENTION_SECONDS => Ok(TargetStats::ContentionSeconds(TargetStat {
+                kind: TargetVariant::OST,
                 target,
                 param: Param(p),
                 value,
             })),
             CTIME_AGE_LIMIT => Ok(TargetStats::CtimeAgeLimit(TargetStat {
+                kind: TargetVariant::OST,
                 target,
                 param: Param(p),
                 value,
             })),
             EARLY_LOCK_CANCEL => Ok(TargetStats::EarlyLockCancel(TargetStat {
+                kind: TargetVariant::OST,
                 target,
                 param: Param(p),
                 value,
             })),
             LOCK_COUNT => Ok(TargetStats::LockCount(TargetStat {
+                kind: TargetVariant::OST,
                 target,
                 param: Param(p),
                 value,
             })),
             LOCK_TIMEOUTS => Ok(TargetStats::LockTimeouts(TargetStat {
+                kind: TargetVariant::OST,
                 target,
                 param: Param(p),
                 value,
             })),
             LOCK_UNUSED_COUNT => Ok(TargetStats::LockUnusedCount(TargetStat {
+                kind: TargetVariant::OST,
                 target,
                 param: Param(p),
                 value,
             })),
             LRU_MAX_AGE => Ok(TargetStats::LruMaxAge(TargetStat {
+                kind: TargetVariant::OST,
                 target,
                 param: Param(p),
                 value,
             })),
             LRU_SIZE => Ok(TargetStats::LruSize(TargetStat {
+                kind: TargetVariant::OST,
                 target,
                 param: Param(p),
                 value,
             })),
             MAX_NOLOCK_BYTES => Ok(TargetStats::MaxNolockBytes(TargetStat {
+                kind: TargetVariant::OST,
                 target,
                 param: Param(p),
                 value,
             })),
             MAX_PARALLEL_AST => Ok(TargetStats::MaxParallelAst(TargetStat {
+                kind: TargetVariant::OST,
                 target,
                 param: Param(p),
                 value,
             })),
             RESOURCE_COUNT => Ok(TargetStats::ResourceCount(TargetStat {
+                kind: TargetVariant::OST,
                 target,
                 param: Param(p),
                 value,

--- a/src/oss/obdfilter_parser.rs
+++ b/src/oss/obdfilter_parser.rs
@@ -5,16 +5,15 @@
 use combine::{
     choice,
     error::{ParseError, StreamError},
-    many1, one_of,
-    parser::char::{alpha_num, newline, string},
+    parser::char::{newline, string},
     stream::{Stream, StreamErrorFor},
     Parser,
 };
 
-use base_parsers::{digits, param, period, till_newline};
+use base_parsers::{digits, param, period, target, till_newline};
 use oss::brw_stats_parser::brw_stats;
-use stats::{BrwStats, Param, Record, Stat, Target, TargetStat, TargetStats};
 use stats_parser::stats;
+use types::{BrwStats, Param, Record, Stat, Target, TargetStat, TargetStats, TargetVariant};
 
 pub const STATS: &str = "stats";
 pub const BRW_STATS: &str = "brw_stats";
@@ -59,10 +58,8 @@ where
     I: Stream<Item = char>,
     I::Error: ParseError<I::Item, I::Range, I::Position>,
 {
-    (
-        string("obdfilter").skip(period()),
-        many1(alpha_num().or(one_of("_-".chars()))).skip(period()),
-    ).map(|(_, target)| Target(target))
+    (string("obdfilter").skip(period()), target().skip(period()))
+        .map(|(_, x)| x)
         .message("while parsing target_name")
 }
 
@@ -154,73 +151,88 @@ where
     I: Stream<Item = char>,
     I::Error: ParseError<I::Item, I::Range, I::Position>,
 {
-    #[cfg_attr(rustfmt, rustfmt_skip)]
     (target_name(), obdfilter_stat())
         .and_then(|(target, (param, value))| {
             #[allow(unreachable_patterns)]
-            match value {
-            ObdfilterStat::Stats(value) => Ok(TargetStats::Stats(TargetStat {
-                target,
-                param,
-                value,
-            })),
-            ObdfilterStat::BrwStats(value) => Ok(TargetStats::BrwStats(TargetStat {
-                target,
-                param,
-                value,
-            })),
-            ObdfilterStat::FilesFree(value) => Ok(TargetStats::FilesFree(TargetStat {
-                target,
-                param,
-                value,
-            })),
-            ObdfilterStat::FilesTotal(value) => Ok(TargetStats::FilesTotal(TargetStat {
-                target,
-                param,
-                value,
-            })),
-            ObdfilterStat::FsType(value) => Ok(TargetStats::FsType(TargetStat {
-                target,
-                param,
-                value,
-            })),
-            ObdfilterStat::BytesAvail(value) => Ok(TargetStats::BytesAvail(TargetStat {
-                target,
-                param,
-                value,
-            })),
-            ObdfilterStat::BytesFree(value) => Ok(TargetStats::BytesFree(TargetStat {
-                target,
-                param,
-                value,
-            })),
-            ObdfilterStat::BytesTotal(value) => Ok(TargetStats::BytesTotal(TargetStat {
-                target,
-                param,
-                value,
-            })),
-            ObdfilterStat::NumExports(value) => Ok(TargetStats::NumExports(TargetStat {
-                target,                
-                param,
-                value,
-            })),
-            ObdfilterStat::TotDirty(value) => Ok(TargetStats::TotDirty(TargetStat {
-                target,
-                param,
-                value,
-            })),
-            ObdfilterStat::TotGranted(value) => Ok(TargetStats::TotGranted(TargetStat {
-                target,
-                param,
-                value,
-            })),
-            ObdfilterStat::TotPending(value) => Ok(TargetStats::TotPending(TargetStat {
-                target,
-                param,
-                value,
-            })),
-            _ => Err(StreamErrorFor::<I>::expected_static_message("ObdfilterStat Variant")),
-        }})
+            let r = match value {
+                ObdfilterStat::Stats(value) => Ok(TargetStats::Stats(TargetStat {
+                    kind: TargetVariant::OST,
+                    target,
+                    param,
+                    value,
+                })),
+                ObdfilterStat::BrwStats(value) => Ok(TargetStats::BrwStats(TargetStat {
+                    kind: TargetVariant::OST,
+                    target,
+                    param,
+                    value,
+                })),
+                ObdfilterStat::FilesFree(value) => Ok(TargetStats::FilesFree(TargetStat {
+                    kind: TargetVariant::OST,
+                    target,
+                    param,
+                    value,
+                })),
+                ObdfilterStat::FilesTotal(value) => Ok(TargetStats::FilesTotal(TargetStat {
+                    kind: TargetVariant::OST,
+                    target,
+                    param,
+                    value,
+                })),
+                ObdfilterStat::FsType(value) => Ok(TargetStats::FsType(TargetStat {
+                    kind: TargetVariant::OST,
+                    target,
+                    param,
+                    value,
+                })),
+                ObdfilterStat::BytesAvail(value) => Ok(TargetStats::BytesAvail(TargetStat {
+                    kind: TargetVariant::OST,
+                    target,
+                    param,
+                    value,
+                })),
+                ObdfilterStat::BytesFree(value) => Ok(TargetStats::BytesFree(TargetStat {
+                    kind: TargetVariant::OST,
+                    target,
+                    param,
+                    value,
+                })),
+                ObdfilterStat::BytesTotal(value) => Ok(TargetStats::BytesTotal(TargetStat {
+                    kind: TargetVariant::OST,
+                    target,
+                    param,
+                    value,
+                })),
+                ObdfilterStat::NumExports(value) => Ok(TargetStats::NumExports(TargetStat {
+                    kind: TargetVariant::OST,
+                    target,
+                    param,
+                    value,
+                })),
+                ObdfilterStat::TotDirty(value) => Ok(TargetStats::TotDirty(TargetStat {
+                    kind: TargetVariant::OST,
+                    target,
+                    param,
+                    value,
+                })),
+                ObdfilterStat::TotGranted(value) => Ok(TargetStats::TotGranted(TargetStat {
+                    kind: TargetVariant::OST,
+                    target,
+                    param,
+                    value,
+                })),
+                ObdfilterStat::TotPending(value) => Ok(TargetStats::TotPending(TargetStat {
+                    kind: TargetVariant::OST,
+                    target,
+                    param,
+                    value,
+                })),
+                _ => Err(StreamErrorFor::<I>::expected_static_message(
+                    "ObdfilterStat Variant",
+                )),
+            };
+            r
+        })
         .map(Record::Target)
         .message("while parsing obdfilter")
 }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -1,0 +1,29 @@
+// Copyright (c) 2018 DDN. All rights reserved.
+// Use of this source code is governed by a MIT-style
+// license that can be found in the LICENSE file.
+
+use mgs::mgs_parser;
+use oss::oss_parser;
+use top_level_parser;
+
+use combine::{choice, error::ParseError, many, Parser, Stream};
+use types::Record;
+
+pub fn params() -> Vec<String> {
+    let mut a = top_level_parser::top_level_params();
+    a.extend(mgs_parser::params());
+    a.extend(oss_parser::params());
+    a
+}
+
+pub fn parse<I>() -> impl Parser<Input = I, Output = Vec<Record>>
+where
+    I: Stream<Item = char>,
+    I::Error: ParseError<I::Item, I::Range, I::Position>,
+{
+    many(choice((
+        top_level_parser::parse(),
+        mgs_parser::parse(),
+        oss_parser::parse(),
+    )))
+}

--- a/src/stats_parser.rs
+++ b/src/stats_parser.rs
@@ -14,9 +14,9 @@ use combine::{
     token, Parser,
 };
 
-use base_parsers::{digits, not_word, word};
+use base_parsers::{digits, not_words, word};
 use snapshot_time::snapshot_time;
-use stats::Stat;
+use types::Stat;
 
 fn name_count_units<I>() -> impl Parser<Input = I, Output = (String, u64, String)>
 where
@@ -24,7 +24,7 @@ where
     I::Error: ParseError<I::Item, I::Range, I::Position>,
 {
     (
-        not_word("obdfilter").skip(spaces()),
+        not_words(&["obdfilter", "mgs"]).skip(spaces()),
         digits(),
         spaces().with(string("samples")),
         spaces().with(between(token('['), token(']'), word())),

--- a/src/top_level_parser.rs
+++ b/src/top_level_parser.rs
@@ -11,7 +11,7 @@ use combine::{
     Parser,
 };
 
-use stats::{HostStat, HostStats, Param, Record};
+use types::{HostStat, HostStats, Param, Record};
 
 pub const MEMUSED_MAX: &str = "memused_max";
 pub const MEMUSED: &str = "memused";
@@ -52,31 +52,26 @@ where
     I: Stream<Item = char>,
     I::Error: ParseError<I::Item, I::Range, I::Position>,
 {
-    #[cfg_attr(rustfmt, rustfmt_skip)]
     top_level_stat()
         .and_then(|(param, v)| {
             #[allow(unreachable_patterns)]
-            match v {
-                TopLevelStat::Memused(value) => Ok(HostStats::Memused(HostStat {
-                    param,
-                    value,
-                })),
-                TopLevelStat::MemusedMax(value) => Ok(HostStats::MemusedMax(HostStat {
-                    param,
-                    value,
-                })),
-                TopLevelStat::LnetMemused(value) => Ok(HostStats::LNetMemUsed(HostStat {
-                    param,
-                    value,
-                })),
-                TopLevelStat::HealthCheck(value) => Ok(HostStats::HealthCheck(HostStat {
-                    param,
-                    value,
-                })),
+            let r = match v {
+                TopLevelStat::Memused(value) => Ok(HostStats::Memused(HostStat { param, value })),
+                TopLevelStat::MemusedMax(value) => {
+                    Ok(HostStats::MemusedMax(HostStat { param, value }))
+                }
+                TopLevelStat::LnetMemused(value) => {
+                    Ok(HostStats::LNetMemUsed(HostStat { param, value }))
+                }
+                TopLevelStat::HealthCheck(value) => {
+                    Ok(HostStats::HealthCheck(HostStat { param, value }))
+                }
                 _ => Err(StreamErrorFor::<I>::unexpected_static_message(
                     "Unexpected top-level param",
                 )),
-            }
+            };
+
+            r
         })
         .map(Record::Host)
         .message("while parsing top_level_param")
@@ -87,7 +82,7 @@ mod tests {
 
     use super::*;
     use combine::stream::state::{SourcePosition, State};
-    use stats::{HostStat, HostStats, Param};
+    use types::{HostStat, HostStats, Param};
 
     #[test]
     fn test_params() {

--- a/src/types.rs
+++ b/src/types.rs
@@ -33,8 +33,15 @@ pub struct HostStat<T> {
 }
 
 #[derive(PartialEq, Debug, Serialize)]
+pub enum TargetVariant {
+    OST,
+    MGT,
+}
+
+#[derive(PartialEq, Debug, Serialize)]
 /// Stats specific to a target.
 pub struct TargetStat<T> {
+    pub kind: TargetVariant,
     pub param: Param,
     pub target: Target,
     pub value: T,
@@ -98,6 +105,8 @@ pub enum TargetStats {
     MaxNolockBytes(TargetStat<u64>),
     MaxParallelAst(TargetStat<u64>),
     ResourceCount(TargetStat<u64>),
+    ThreadsMin(TargetStat<u64>),
+    ThreadsMax(TargetStat<u64>),
 }
 
 #[derive(PartialEq, Debug, Serialize)]


### PR DESCRIPTION
This patch adds parsers for MGTs. It also refactors some file names for
better clarity and adds a variant field for clarity of which type of
target we are using.

Signed-off-by: Joe Grund <jgrund@whamcloud.io>