### PR TITLE
Add OST Jobstats

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,19 +5,19 @@ jobs:
   include:
     - stage: test
       name: "Unit Tests"
-      rust: stable
+      rust: 1.29.0
       script:
         - cargo test
     - stage: test
       name: "Format Check"
-      rust: stable
+      rust: 1.29.0
       before_script:
         - rustup component add rustfmt-preview
       script:
         - cargo fmt --all -- --check
     - stage: test
       name: "Linting Check"
-      rust: nightly
+      rust: 1.29.0
       before_script:
         - rustup component add clippy-preview
       script:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -47,7 +47,7 @@ dependencies = [
 
 [[package]]
 name = "combine"
-version = "3.5.1"
+version = "3.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "ascii 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -97,13 +97,13 @@ name = "lustre_collector"
 version = "0.1.0"
 dependencies = [
  "clap 2.32.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "combine 3.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "combine 3.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "error-chain 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "pretty_assertions 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.71 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.71 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.26 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_yaml 0.8.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_yaml 0.8.4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -184,7 +184,7 @@ dependencies = [
 
 [[package]]
 name = "serde_yaml"
-version = "0.8.3"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "dtoa 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -288,7 +288,7 @@ dependencies = [
 "checksum bitflags 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "228047a76f468627ca71776ecdebd732a3423081fcf5125585bcd7c49886ce12"
 "checksum byteorder 1.2.4 (registry+https://github.com/rust-lang/crates.io-index)" = "8389c509ec62b9fe8eca58c502a0acaf017737355615243496cde4994f8fa4f9"
 "checksum clap 2.32.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b957d88f4b6a63b9d70d5f454ac8011819c6efa7727858f458ab71c756ce2d3e"
-"checksum combine 3.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "7e67be864b6450c26fdb9242dee53a46fb9648d0b1a65521a6a1947b54fa011e"
+"checksum combine 3.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "54cedd8056314afe0d844a37a207007edf8a45f2cc452fd77629cd63c221740e"
 "checksum difference 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "524cbf6897b527295dff137cec09ecf3a05f4fddffd7dfcd1585403449e74198"
 "checksum dtoa 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)" = "6d301140eb411af13d3115f9a562c85cc6b541ade9dfa314132244aaee7489dd"
 "checksum either 1.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3be565ca5c557d7f59e7cfcf1844f9e3033650c929c6566f511e8005f205c1d0"
@@ -306,7 +306,7 @@ dependencies = [
 "checksum serde 1.0.71 (registry+https://github.com/rust-lang/crates.io-index)" = "6dfad05c8854584e5f72fb859385ecdfa03af69c3fd0572f0da2d4c95f060bdb"
 "checksum serde_derive 1.0.71 (registry+https://github.com/rust-lang/crates.io-index)" = "b719c6d5e9f73fbc37892246d5852333f040caa617b8873c6aced84bcb28e7bb"
 "checksum serde_json 1.0.26 (registry+https://github.com/rust-lang/crates.io-index)" = "44dd2cfde475037451fa99b7e5df77aa3cfd1536575fa8e7a538ab36dcde49ae"
-"checksum serde_yaml 0.8.3 (registry+https://github.com/rust-lang/crates.io-index)" = "46f14cb1eaa4ee296e6d9e0cc8ea96f772369d7b40987253772efbe2a63fd984"
+"checksum serde_yaml 0.8.4 (registry+https://github.com/rust-lang/crates.io-index)" = "1d58de5bf17f1e4ef9f12e774e00b2f11bd68579cff2d5918b6f79bf6f5270dd"
 "checksum strsim 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "bb4f380125926a99e52bc279241539c018323fab05ad6368b56f93d9369ff550"
 "checksum syn 0.14.8 (registry+https://github.com/rust-lang/crates.io-index)" = "b7bfcbb0c068d0f642a0ffbd5c604965a360a61f99e8add013cef23a838614f3"
 "checksum termion 1.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "689a3bdfaab439fd92bc87df5c4c78417d3cbe537487274e9b0b2dce76e92096"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,11 +4,11 @@ version = "0.1.0"
 authors = ["IML Team <iml@whamcloud.com>"]
 
 [dependencies]
-combine = "3.5.1"
+combine = "3.5.2"
 serde = "1.0"
 serde_derive = "1.0"
 serde_json = "1.0"
-serde_yaml = "0.8.3"
+serde_yaml = "0.8.4"
 clap = "2.32.0"
 
 [dependencies.error-chain]

--- a/src/base_parsers.rs
+++ b/src/base_parsers.rs
@@ -71,7 +71,7 @@ where
 {
     try(word().then(move |y| {
         for &x in xs {
-            if x.to_string() == y {
+            if x == y {
                 return unexpected(x).map(|_| "".to_string()).right();
             }
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,6 +4,7 @@
 
 #![allow(unknown_lints)]
 #![warn(clippy)]
+#![cfg_attr(feature = "cargo-clippy", allow(let_and_return))]
 // `error_chain!` can recurse deeply
 #![recursion_limit = "1024"]
 
@@ -72,11 +73,10 @@ fn main() {
                 .short("f")
                 .long("format")
                 .possible_values(&variants.iter().map(|x| x.as_str()).collect::<Vec<_>>()[..])
-                .default_value(&variants.iter().nth(0).unwrap())
+                .default_value(&variants[0])
                 .help("Sets the output formatting")
                 .takes_value(true),
-        )
-        .get_matches();
+        ).get_matches();
 
     let format = value_t!(matches, "format", Format).unwrap_or_else(|e| e.exit());
 

--- a/src/mgs/mgs_parser.rs
+++ b/src/mgs/mgs_parser.rs
@@ -25,7 +25,8 @@ pub fn params() -> Vec<String> {
         format!("mgs.*.mgs.{}", THREADS_MAX),
         format!("mgs.*.mgs.{}", THREADS_MIN),
         format!("mgs.*.{}", NUM_EXPORTS),
-    ].into_iter()
+    ]
+        .into_iter()
         .map(|x| x.to_owned())
         .collect::<Vec<_>>()
 }
@@ -72,7 +73,8 @@ where
                     digits().skip(newline()).map(MgsStat::ThreadsMax),
                 ),
             )),
-        ).map(|(_, (y, z))| (y, z)),
+        )
+            .map(|(_, (y, z))| (y, z)),
     ))
 }
 
@@ -115,7 +117,6 @@ where
             };
 
             r
-        })
-        .map(Record::Target)
+        }).map(Record::Target)
         .message("while parsing mgs params")
 }

--- a/src/oss/brw_stats_parser.rs
+++ b/src/oss/brw_stats_parser.rs
@@ -34,7 +34,8 @@ where
         spaces(),
         string("write"),
         till_newline(),
-    ).map(|_| ())
+    )
+        .map(|_| ())
 }
 
 fn header<I>() -> impl Parser<Input = I, Output = BrwStats>
@@ -77,7 +78,8 @@ where
         spaces().with(digits()),
         spaces().with(digits()),
         till_newline(),
-    ).map(|(name, _, read, _, _, _, write, _, _, _)| BrwStatsBucket { name, read, write })
+    )
+        .map(|(name, _, read, _, _, _, write, _, _, _)| BrwStatsBucket { name, read, write })
 }
 
 fn section<I>() -> impl Parser<Input = I, Output = BrwStats>
@@ -89,10 +91,11 @@ where
         rw_columns().skip(newline()),
         header().skip(newline()),
         many(bucket().skip(newline())).skip(spaces()),
-    ).map(|(_, stats, xs)| BrwStats {
-        buckets: xs,
-        ..stats
-    })
+    )
+        .map(|(_, stats, xs)| BrwStats {
+            buckets: xs,
+            ..stats
+        })
 }
 
 pub fn brw_stats<I>() -> impl Parser<Input = I, Output = Vec<BrwStats>>
@@ -112,10 +115,10 @@ mod tests {
     fn test_human_to_bytes() {
         assert_eq!(human_to_bytes((1, Some('k'))), 1024);
         assert_eq!(human_to_bytes((2, Some('K'))), 2048);
-        assert_eq!(human_to_bytes((1, Some('m'))), 1048576);
-        assert_eq!(human_to_bytes((2, Some('M'))), 2097152);
-        assert_eq!(human_to_bytes((1, Some('g'))), 1073741824);
-        assert_eq!(human_to_bytes((5, Some('G'))), 5368709120);
+        assert_eq!(human_to_bytes((1, Some('m'))), 1_048_576);
+        assert_eq!(human_to_bytes((2, Some('M'))), 2_097_152);
+        assert_eq!(human_to_bytes((1, Some('g'))), 1_073_741_824);
+        assert_eq!(human_to_bytes((5, Some('G'))), 5_368_709_120);
         assert_eq!(human_to_bytes((5, None)), 5);
     }
 
@@ -625,22 +628,22 @@ disk I/O size          ios   % cum % |  ios         % cum %
                         unit: "ios".to_string(),
                         buckets: vec![
                             BrwStatsBucket {
-                                name: 131072,
+                                name: 131_072,
                                 read: 0,
                                 write: 1,
                             },
                             BrwStatsBucket {
-                                name: 262144,
+                                name: 262_144,
                                 read: 0,
                                 write: 0,
                             },
                             BrwStatsBucket {
-                                name: 524288,
+                                name: 524_288,
                                 read: 0,
                                 write: 0,
                             },
                             BrwStatsBucket {
-                                name: 1048576,
+                                name: 1_048_576,
                                 read: 0,
                                 write: 32,
                             },

--- a/src/oss/job_stats.rs
+++ b/src/oss/job_stats.rs
@@ -58,6 +58,7 @@ where
 mod tests {
     use super::*;
     use serde_yaml;
+    use types::{BytesStat, ReqsStat};
 
     #[test]
     fn test_yaml_deserialize() {
@@ -77,9 +78,67 @@ mod tests {
   set_info:        { samples:           0, unit:  reqs }
   quotactl:        { samples:           0, unit:  reqs }"#;
 
-        assert_eq!(
-            serde_yaml::from_str::<JobStatsOst>(x).unwrap(),
-            JobStatsOst { job_stats: None }
-        )
+        let expected = JobStatsOst {
+            job_stats: Some(vec![JobStatOst {
+                job_id: "cp.0".to_string(),
+                snapshot_time: 1_537_070_542,
+                read_bytes: BytesStat {
+                    samples: 256,
+                    unit: "bytes".to_string(),
+                    min: 4_194_304,
+                    max: 4_194_304,
+                    sum: 1_073_741_824,
+                },
+                write_bytes: BytesStat {
+                    samples: 0,
+                    unit: "bytes".to_string(),
+                    min: 0,
+                    max: 0,
+                    sum: 0,
+                },
+                getattr: ReqsStat {
+                    samples: 0,
+                    unit: "reqs".to_string(),
+                },
+                setattr: ReqsStat {
+                    samples: 0,
+                    unit: "reqs".to_string(),
+                },
+                punch: ReqsStat {
+                    samples: 0,
+                    unit: "reqs".to_string(),
+                },
+                sync: ReqsStat {
+                    samples: 0,
+                    unit: "reqs".to_string(),
+                },
+                destroy: ReqsStat {
+                    samples: 0,
+                    unit: "reqs".to_string(),
+                },
+                create: ReqsStat {
+                    samples: 0,
+                    unit: "reqs".to_string(),
+                },
+                statfs: ReqsStat {
+                    samples: 0,
+                    unit: "reqs".to_string(),
+                },
+                get_info: ReqsStat {
+                    samples: 0,
+                    unit: "reqs".to_string(),
+                },
+                set_info: ReqsStat {
+                    samples: 0,
+                    unit: "reqs".to_string(),
+                },
+                quotactl: ReqsStat {
+                    samples: 0,
+                    unit: "reqs".to_string(),
+                },
+            }]),
+        };
+
+        assert_eq!(serde_yaml::from_str::<JobStatsOst>(x).unwrap(), expected)
     }
 }

--- a/src/oss/job_stats.rs
+++ b/src/oss/job_stats.rs
@@ -1,0 +1,85 @@
+// Copyright (c) 2018 DDN. All rights reserved.
+// Use of this source code is governed by a MIT-style
+// license that can be found in the LICENSE file.
+
+use combine::{
+    error::{ParseError, StreamError},
+    optional,
+    parser::{
+        char::{alpha_num, newline},
+        repeat::take_until,
+    },
+    stream::{Stream, StreamErrorFor},
+    try, Parser,
+};
+
+use serde_yaml;
+
+use types::{JobStatOst, JobStatsOst};
+
+/*
+obdfilter.fs-OST0001.job_stats=job_stats:
+obdfilter.fs-OST0003.job_stats=
+job_stats:
+- job_id:          cp.0
+  snapshot_time:   1537063675
+  read_bytes:      { samples:         256, unit: bytes, min: 4194304, max: 4194304, sum:      1073741824 }
+  write_bytes:     { samples:         256, unit: bytes, min: 4194304, max: 4194304, sum:      1073741824 }
+  getattr:         { samples:           0, unit:  reqs }
+  setattr:         { samples:           0, unit:  reqs }
+  punch:           { samples:           0, unit:  reqs }
+  sync:            { samples:           0, unit:  reqs }
+  destroy:         { samples:           0, unit:  reqs }
+  create:          { samples:           0, unit:  reqs }
+  statfs:          { samples:           0, unit:  reqs }
+  get_info:        { samples:           0, unit:  reqs }
+  set_info:        { samples:           0, unit:  reqs }
+  quotactl:        { samples:           0, unit:  reqs }
+*/
+
+pub fn parse<I>() -> impl Parser<Input = I, Output = Option<Vec<JobStatOst>>>
+where
+    I: Stream<Item = char>,
+    I::Error: ParseError<I::Item, I::Range, I::Position>,
+{
+    (
+        optional(newline()), // If Jobstats are present, the whole yaml blob will be on a newline
+        take_until(try((newline(), alpha_num()))),
+    )
+        .skip(newline())
+        .and_then(|(_, x): (_, String)| {
+            serde_yaml::from_str(&x)
+                .map(|x: JobStatsOst| x.job_stats)
+                .map_err(StreamErrorFor::<I>::other)
+        })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_yaml;
+
+    #[test]
+    fn test_yaml_deserialize() {
+        let x = r#"job_stats:
+- job_id:          cp.0
+  snapshot_time:   1537070542
+  read_bytes:      { samples:         256, unit: bytes, min: 4194304, max: 4194304, sum:      1073741824 }
+  write_bytes:     { samples:           0, unit: bytes, min:       0, max:       0, sum:               0 }
+  getattr:         { samples:           0, unit:  reqs }
+  setattr:         { samples:           0, unit:  reqs }
+  punch:           { samples:           0, unit:  reqs }
+  sync:            { samples:           0, unit:  reqs }
+  destroy:         { samples:           0, unit:  reqs }
+  create:          { samples:           0, unit:  reqs }
+  statfs:          { samples:           0, unit:  reqs }
+  get_info:        { samples:           0, unit:  reqs }
+  set_info:        { samples:           0, unit:  reqs }
+  quotactl:        { samples:           0, unit:  reqs }"#;
+
+        assert_eq!(
+            serde_yaml::from_str::<JobStatsOst>(x).unwrap(),
+            JobStatsOst { job_stats: None }
+        )
+    }
+}

--- a/src/oss/job_stats.rs
+++ b/src/oss/job_stats.rs
@@ -17,26 +17,6 @@ use serde_yaml;
 
 use types::{JobStatOst, JobStatsOst};
 
-/*
-obdfilter.fs-OST0001.job_stats=job_stats:
-obdfilter.fs-OST0003.job_stats=
-job_stats:
-- job_id:          cp.0
-  snapshot_time:   1537063675
-  read_bytes:      { samples:         256, unit: bytes, min: 4194304, max: 4194304, sum:      1073741824 }
-  write_bytes:     { samples:         256, unit: bytes, min: 4194304, max: 4194304, sum:      1073741824 }
-  getattr:         { samples:           0, unit:  reqs }
-  setattr:         { samples:           0, unit:  reqs }
-  punch:           { samples:           0, unit:  reqs }
-  sync:            { samples:           0, unit:  reqs }
-  destroy:         { samples:           0, unit:  reqs }
-  create:          { samples:           0, unit:  reqs }
-  statfs:          { samples:           0, unit:  reqs }
-  get_info:        { samples:           0, unit:  reqs }
-  set_info:        { samples:           0, unit:  reqs }
-  quotactl:        { samples:           0, unit:  reqs }
-*/
-
 pub fn parse<I>() -> impl Parser<Input = I, Output = Option<Vec<JobStatOst>>>
 where
     I: Stream<Item = char>,

--- a/src/oss/ldlm_parser.rs
+++ b/src/oss/ldlm_parser.rs
@@ -59,15 +59,15 @@ where
     (
         string("ldlm.namespaces."),
         choice((string("mdt-"), string("filter-"))).with(target()),
-    ).and_then(|(_, Target(x))| {
+    )
+        .and_then(|(_, Target(x))| {
             let xs: Vec<&str> = x.split("_UUID").collect();
 
             match xs.as_slice() {
                 [y, _] => Ok(Target(y.to_string())),
                 _ => Err(StreamErrorFor::<I>::expected_static_message("_UUID")),
             }
-        })
-        .skip(period())
+        }).skip(period())
         .message("while parsing lock_namespaces")
 }
 
@@ -174,8 +174,7 @@ where
             _ => Err(StreamErrorFor::<I>::unexpected_static_message(
                 "Unexpected top-level param",
             )),
-        })
-        .map(Record::Target)
+        }).map(Record::Target)
         .message("while parsing ldlm")
 }
 

--- a/src/oss/mod.rs
+++ b/src/oss/mod.rs
@@ -3,6 +3,7 @@
 // license that can be found in the LICENSE file.
 
 pub mod brw_stats_parser;
+pub mod job_stats;
 pub mod ldlm_parser;
 pub mod obdfilter_parser;
 pub mod oss_parser;

--- a/src/oss/oss_parser.rs
+++ b/src/oss/oss_parser.rs
@@ -144,8 +144,8 @@ obdfilter.fs-OST0000.tot_pending=0
                                 units: "bytes".to_string(),
                                 samples: 9,
                                 min: Some(98303),
-                                max: Some(4194304),
-                                sum: Some(33554431),
+                                max: Some(4_194_304),
+                                sum: Some(33_554_431),
                                 sumsquare: None,
                             },
                             Stat {
@@ -484,22 +484,22 @@ obdfilter.fs-OST0000.tot_pending=0
                                 unit: "ios".to_string(),
                                 buckets: vec![
                                     BrwStatsBucket {
-                                        name: 131072,
+                                        name: 131_072,
                                         read: 0,
                                         write: 1,
                                     },
                                     BrwStatsBucket {
-                                        name: 262144,
+                                        name: 262_144,
                                         read: 0,
                                         write: 0,
                                     },
                                     BrwStatsBucket {
-                                        name: 524288,
+                                        name: 524_288,
                                         read: 0,
                                         write: 0,
                                     },
                                     BrwStatsBucket {
-                                        name: 1048576,
+                                        name: 1_048_576,
                                         read: 0,
                                         write: 32,
                                     },
@@ -511,13 +511,13 @@ obdfilter.fs-OST0000.tot_pending=0
                         kind: TargetVariant::OST,
                         param: Param("filesfree".to_string()),
                         target: Target("fs-OST0000".to_string()),
-                        value: 327382,
+                        value: 327_382,
                     })),
                     Record::Target(TargetStats::FilesTotal(TargetStat {
                         kind: TargetVariant::OST,
                         param: Param("filestotal".to_string()),
                         target: Target("fs-OST0000".to_string()),
-                        value: 327680,
+                        value: 327_680,
                     })),
                     Record::Target(TargetStats::FsType(TargetStat {
                         kind: TargetVariant::OST,
@@ -529,19 +529,19 @@ obdfilter.fs-OST0000.tot_pending=0
                         kind: TargetVariant::OST,
                         param: Param("kbytesavail".to_string()),
                         target: Target("fs-OST0000".to_string()),
-                        value: 4594143232,
+                        value: 4_594_143_232,
                     })),
                     Record::Target(TargetStats::BytesFree(TargetStat {
                         kind: TargetVariant::OST,
                         param: Param("kbytesfree".to_string()),
                         target: Target("fs-OST0000".to_string()),
-                        value: 4879355904,
+                        value: 4_879_355_904,
                     })),
                     Record::Target(TargetStats::BytesTotal(TargetStat {
                         kind: TargetVariant::OST,
                         param: Param("kbytestotal".to_string()),
                         target: Target("fs-OST0000".to_string()),
-                        value: 4947677184,
+                        value: 4_947_677_184,
                     })),
                     Record::Target(TargetStats::NumExports(TargetStat {
                         kind: TargetVariant::OST,
@@ -559,7 +559,7 @@ obdfilter.fs-OST0000.tot_pending=0
                         kind: TargetVariant::OST,
                         param: Param("tot_granted".to_string()),
                         target: Target("fs-OST0000".to_string()),
-                        value: 8666816,
+                        value: 8_666_816,
                     })),
                     Record::Target(TargetStats::TotPending(TargetStat {
                         kind: TargetVariant::OST,

--- a/src/snapshot_time.rs
+++ b/src/snapshot_time.rs
@@ -18,7 +18,8 @@ where
         spaces(),
         digits().skip(token('.')),
         digits().skip(till_newline()),
-    ).map(|(_, _, secs, nsecs)| format!("{}.{}", secs, nsecs))
+    )
+        .map(|(_, _, secs, nsecs)| format!("{}.{}", secs, nsecs))
 }
 
 #[cfg(test)]

--- a/src/stats_parser.rs
+++ b/src/stats_parser.rs
@@ -28,7 +28,8 @@ where
         digits(),
         spaces().with(string("samples")),
         spaces().with(between(token('['), token(']'), word())),
-    ).map(|(x, y, _, z)| (x, y, z))
+    )
+        .map(|(x, y, _, z)| (x, y, z))
 }
 
 fn min_max_sum<I>() -> impl Parser<Input = I, Output = (u64, u64, u64)>
@@ -65,37 +66,38 @@ where
                 or(newline().map(|_| None), sum_sq().map(Some).skip(newline())),
             ),
         ),
-    ).map(
-        |((name, samples, units), (min_max, sum))| match (min_max, sum) {
-            (Some((min, max, sum)), Some(sumsquare)) => Stat {
-                name,
-                samples,
-                units,
-                min: Some(min),
-                max: Some(max),
-                sum: Some(sum),
-                sumsquare: Some(sumsquare),
-            },
-            (Some((min, max, sum)), None) => Stat {
-                name,
-                samples,
-                units,
-                min: Some(min),
-                max: Some(max),
-                sum: Some(sum),
-                sumsquare: None,
-            },
-            (None, _) => Stat {
-                name,
-                samples,
-                units,
-                min: None,
-                max: None,
-                sum: None,
-                sumsquare: None,
-            },
-        },
     )
+        .map(
+            |((name, samples, units), (min_max, sum))| match (min_max, sum) {
+                (Some((min, max, sum)), Some(sumsquare)) => Stat {
+                    name,
+                    samples,
+                    units,
+                    min: Some(min),
+                    max: Some(max),
+                    sum: Some(sum),
+                    sumsquare: Some(sumsquare),
+                },
+                (Some((min, max, sum)), None) => Stat {
+                    name,
+                    samples,
+                    units,
+                    min: Some(min),
+                    max: Some(max),
+                    sum: Some(sum),
+                    sumsquare: None,
+                },
+                (None, _) => Stat {
+                    name,
+                    samples,
+                    units,
+                    min: None,
+                    max: None,
+                    sum: None,
+                    sumsquare: None,
+                },
+            },
+        )
 }
 
 pub fn stats<I>() -> impl Parser<Input = I, Output = Vec<Stat>>
@@ -183,7 +185,7 @@ mod tests {
                     min: Some(15),
                     max: Some(72),
                     sum: Some(47014),
-                    sumsquare: Some(2156132)
+                    sumsquare: Some(2_156_132)
                 },
                 State {
                     input: "",
@@ -223,8 +225,8 @@ ping                      1075 samples [reqs]
                         samples: 9,
                         units: "bytes".to_string(),
                         min: Some(98303),
-                        max: Some(4194304),
-                        sum: Some(33554431),
+                        max: Some(4_194_304),
+                        sum: Some(33_554_431),
                         sumsquare: None,
                     },
                     Stat {

--- a/src/top_level_parser.rs
+++ b/src/top_level_parser.rs
@@ -72,8 +72,7 @@ where
             };
 
             r
-        })
-        .map(Record::Host)
+        }).map(Record::Host)
         .message("while parsing top_level_param")
 }
 
@@ -106,7 +105,7 @@ mod tests {
             Ok((
                 Record::Host(HostStats::MemusedMax(HostStat {
                     param: Param(MEMUSED_MAX.to_string()),
-                    value: 77991501
+                    value: 77_991_501
                 })),
                 State {
                     input: "",

--- a/src/types.rs
+++ b/src/types.rs
@@ -15,6 +15,44 @@ pub struct Target(pub String);
 pub struct Param(pub String);
 
 #[derive(PartialEq, Debug, Serialize, Deserialize)]
+pub struct ReqsStat {
+    pub samples: i64,
+    pub unit: String,
+}
+
+#[derive(PartialEq, Debug, Serialize, Deserialize)]
+pub struct BytesStat {
+    pub samples: i64,
+    pub unit: String,
+    pub min: i64,
+    pub max: i64,
+    pub sum: i64,
+}
+
+#[derive(PartialEq, Debug, Serialize, Deserialize)]
+pub struct JobStatsOst {
+    pub job_stats: Option<Vec<JobStatOst>>,
+}
+
+#[derive(PartialEq, Debug, Serialize, Deserialize)]
+pub struct JobStatOst {
+    pub job_id: String,
+    pub snapshot_time: i64,
+    pub read_bytes: BytesStat,
+    pub write_bytes: BytesStat,
+    pub getattr: ReqsStat,
+    pub setattr: ReqsStat,
+    pub punch: ReqsStat,
+    pub sync: ReqsStat,
+    pub destroy: ReqsStat,
+    pub create: ReqsStat,
+    pub statfs: ReqsStat,
+    pub get_info: ReqsStat,
+    pub set_info: ReqsStat,
+    pub quotactl: ReqsStat,
+}
+
+#[derive(PartialEq, Debug, Serialize, Deserialize)]
 pub struct Stat {
     pub name: String,
     pub units: String,
@@ -75,6 +113,7 @@ pub enum HostStats {
 #[serde(untagged)]
 pub enum TargetStats {
     /// Operations per OST. Read and write data is particularly interesting
+    JobStatsOst(TargetStat<Option<Vec<JobStatOst>>>),
     Stats(TargetStat<Vec<Stat>>),
     BrwStats(TargetStat<Vec<BrwStats>>),
     /// Available inodes


### PR DESCRIPTION
Add support for grabbing jobstats in obdfilter.

The approach here is to eagerly take content when we know we are dealing
with jobstats, until we hit a well-known delimiter.

We then take that output, and parse it using serde_yaml into a struct,
as we know the content we've taken is valid YAML.

Ironically, the struct could later be serialized back to YAML (alongside
all the other stats) if one chooses.

Signed-off-by: Joe Grund <jgrund@whamcloud.io>