### PR TITLE
Bump to 2018 edition

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,23 +1,20 @@
 language: rust
+rust: 1.31.0
 cache: cargo
-
 jobs:
   include:
     - stage: test
       name: "Unit Tests"
-      rust: 1.29.0
       script:
         - cargo test
     - stage: test
       name: "Format Check"
-      rust: 1.29.0
       before_script:
         - rustup component add rustfmt-preview
       script:
         - cargo fmt --all -- --check
     - stage: test
       name: "Linting Check"
-      rust: 1.29.0
       before_script:
         - rustup component add clippy-preview
       script:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,12 +3,12 @@ name = "ansi_term"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "winapi 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "ascii"
-version = "0.7.1"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -16,9 +16,9 @@ name = "atty"
 version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "libc 0.2.43 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.45 (registry+https://github.com/rust-lang/crates.io-index)",
  "termion 1.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "winapi 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -28,7 +28,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "byteorder"
-version = "1.2.4"
+version = "1.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "cfg-if"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -47,13 +52,13 @@ dependencies = [
 
 [[package]]
 name = "combine"
-version = "3.5.2"
+version = "3.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "ascii 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "byteorder 1.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ascii 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "byteorder 1.2.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "either 1.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "memchr 2.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "memchr 2.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "unreachable 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -79,12 +84,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "itoa"
-version = "0.4.2"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "libc"
-version = "0.2.43"
+version = "0.2.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -97,21 +102,23 @@ name = "lustre_collector"
 version = "0.1.0"
 dependencies = [
  "clap 2.32.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "combine 3.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "combine 3.6.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "error-chain 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "pretty_assertions 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.71 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_derive 1.0.71 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_json 1.0.26 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_yaml 0.8.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.82 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_derive 1.0.82 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 1.0.33 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_yaml 0.8.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "memchr"
-version = "2.0.1"
+version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "libc 0.2.43 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cfg-if 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.45 (registry+https://github.com/rust-lang/crates.io-index)",
+ "version_check 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -125,7 +132,7 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "0.4.13"
+version = "0.4.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -133,15 +140,15 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "0.6.6"
+version = "0.6.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "proc-macro2 0.4.13 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 0.4.24 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "redox_syscall"
-version = "0.1.40"
+version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -149,48 +156,48 @@ name = "redox_termios"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "redox_syscall 0.1.40 (registry+https://github.com/rust-lang/crates.io-index)",
+ "redox_syscall 0.1.44 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "ryu"
-version = "0.2.3"
+version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "serde"
-version = "1.0.71"
+version = "1.0.82"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "serde_derive"
-version = "1.0.71"
+version = "1.0.82"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "proc-macro2 0.4.13 (registry+https://github.com/rust-lang/crates.io-index)",
- "quote 0.6.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 0.14.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 0.4.24 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 0.6.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 0.15.22 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.26"
+version = "1.0.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "itoa 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "ryu 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.71 (registry+https://github.com/rust-lang/crates.io-index)",
+ "itoa 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ryu 0.2.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.82 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "serde_yaml"
-version = "0.8.4"
+version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "dtoa 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "linked-hash-map 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.71 (registry+https://github.com/rust-lang/crates.io-index)",
- "yaml-rust 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.82 (registry+https://github.com/rust-lang/crates.io-index)",
+ "yaml-rust 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -200,11 +207,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "syn"
-version = "0.14.8"
+version = "0.15.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "proc-macro2 0.4.13 (registry+https://github.com/rust-lang/crates.io-index)",
- "quote 0.6.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 0.4.24 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 0.6.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -213,8 +220,8 @@ name = "termion"
 version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "libc 0.2.43 (registry+https://github.com/rust-lang/crates.io-index)",
- "redox_syscall 0.1.40 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.45 (registry+https://github.com/rust-lang/crates.io-index)",
+ "redox_syscall 0.1.44 (registry+https://github.com/rust-lang/crates.io-index)",
  "redox_termios 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -250,13 +257,18 @@ version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "version_check"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "void"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "winapi"
-version = "0.3.5"
+version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "winapi-i686-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -275,7 +287,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "yaml-rust"
-version = "0.4.0"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "linked-hash-map 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -283,40 +295,42 @@ dependencies = [
 
 [metadata]
 "checksum ansi_term 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ee49baf6cb617b853aa8d93bf420db2383fab46d314482ca2803b40d5fde979b"
-"checksum ascii 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)" = "3ae7d751998c189c1d4468cf0a39bb2eae052a9c58d50ebb3b9591ee3813ad50"
+"checksum ascii 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)" = "a5fc969a8ce2c9c0c4b0429bb8431544f6658283c8326ba5ff8c762b75369335"
 "checksum atty 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)" = "9a7d5b8723950951411ee34d271d99dddcc2035a16ab25310ea2c8cfd4369652"
 "checksum bitflags 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "228047a76f468627ca71776ecdebd732a3423081fcf5125585bcd7c49886ce12"
-"checksum byteorder 1.2.4 (registry+https://github.com/rust-lang/crates.io-index)" = "8389c509ec62b9fe8eca58c502a0acaf017737355615243496cde4994f8fa4f9"
+"checksum byteorder 1.2.7 (registry+https://github.com/rust-lang/crates.io-index)" = "94f88df23a25417badc922ab0f5716cc1330e87f71ddd9203b3a3ccd9cedf75d"
+"checksum cfg-if 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "082bb9b28e00d3c9d39cc03e64ce4cea0f1bb9b3fde493f0cbc008472d22bdf4"
 "checksum clap 2.32.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b957d88f4b6a63b9d70d5f454ac8011819c6efa7727858f458ab71c756ce2d3e"
-"checksum combine 3.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "54cedd8056314afe0d844a37a207007edf8a45f2cc452fd77629cd63c221740e"
+"checksum combine 3.6.3 (registry+https://github.com/rust-lang/crates.io-index)" = "db733c5d0f4f52e78d4417959cadf0eecc7476e7f9ece05677912571a4af34e2"
 "checksum difference 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "524cbf6897b527295dff137cec09ecf3a05f4fddffd7dfcd1585403449e74198"
 "checksum dtoa 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)" = "6d301140eb411af13d3115f9a562c85cc6b541ade9dfa314132244aaee7489dd"
 "checksum either 1.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3be565ca5c557d7f59e7cfcf1844f9e3033650c929c6566f511e8005f205c1d0"
 "checksum error-chain 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)" = "07e791d3be96241c77c43846b665ef1384606da2cd2a48730abe606a12906e02"
-"checksum itoa 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "5adb58558dcd1d786b5f0bd15f3226ee23486e24b7b58304b60f64dc68e62606"
-"checksum libc 0.2.43 (registry+https://github.com/rust-lang/crates.io-index)" = "76e3a3ef172f1a0b9a9ff0dd1491ae5e6c948b94479a3021819ba7d860c8645d"
+"checksum itoa 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)" = "1306f3464951f30e30d12373d31c79fbd52d236e5e896fd92f96ec7babbbe60b"
+"checksum libc 0.2.45 (registry+https://github.com/rust-lang/crates.io-index)" = "2d2857ec59fadc0773853c664d2d18e7198e83883e7060b63c924cb077bd5c74"
 "checksum linked-hash-map 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "70fb39025bc7cdd76305867c4eccf2f2dcf6e9a57f5b21a93e1c2d86cd03ec9e"
-"checksum memchr 2.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "796fba70e76612589ed2ce7f45282f5af869e0fdd7cc6199fa1aa1f1d591ba9d"
+"checksum memchr 2.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "db4c41318937f6e76648f42826b1d9ade5c09cafb5aef7e351240a70f39206e9"
 "checksum pretty_assertions 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "3a029430f0d744bc3d15dd474d591bed2402b645d024583082b9f63bb936dac6"
-"checksum proc-macro2 0.4.13 (registry+https://github.com/rust-lang/crates.io-index)" = "ee5697238f0d893c7f0ecc59c0999f18d2af85e424de441178bcacc9f9e6cf67"
-"checksum quote 0.6.6 (registry+https://github.com/rust-lang/crates.io-index)" = "ed7d650913520df631972f21e104a4fa2f9c82a14afc65d17b388a2e29731e7c"
-"checksum redox_syscall 0.1.40 (registry+https://github.com/rust-lang/crates.io-index)" = "c214e91d3ecf43e9a4e41e578973adeb14b474f2bee858742d127af75a0112b1"
+"checksum proc-macro2 0.4.24 (registry+https://github.com/rust-lang/crates.io-index)" = "77619697826f31a02ae974457af0b29b723e5619e113e9397b8b82c6bd253f09"
+"checksum quote 0.6.10 (registry+https://github.com/rust-lang/crates.io-index)" = "53fa22a1994bd0f9372d7a816207d8a2677ad0325b073f5c5332760f0fb62b5c"
+"checksum redox_syscall 0.1.44 (registry+https://github.com/rust-lang/crates.io-index)" = "a84bcd297b87a545980a2d25a0beb72a1f490c31f0a9fde52fca35bfbb1ceb70"
 "checksum redox_termios 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "7e891cfe48e9100a70a3b6eb652fef28920c117d366339687bd5576160db0f76"
-"checksum ryu 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "16aa12da69951804cddf5f74d96abcc414a31b064e610dc81e37c1536082f491"
-"checksum serde 1.0.71 (registry+https://github.com/rust-lang/crates.io-index)" = "6dfad05c8854584e5f72fb859385ecdfa03af69c3fd0572f0da2d4c95f060bdb"
-"checksum serde_derive 1.0.71 (registry+https://github.com/rust-lang/crates.io-index)" = "b719c6d5e9f73fbc37892246d5852333f040caa617b8873c6aced84bcb28e7bb"
-"checksum serde_json 1.0.26 (registry+https://github.com/rust-lang/crates.io-index)" = "44dd2cfde475037451fa99b7e5df77aa3cfd1536575fa8e7a538ab36dcde49ae"
-"checksum serde_yaml 0.8.4 (registry+https://github.com/rust-lang/crates.io-index)" = "1d58de5bf17f1e4ef9f12e774e00b2f11bd68579cff2d5918b6f79bf6f5270dd"
+"checksum ryu 0.2.7 (registry+https://github.com/rust-lang/crates.io-index)" = "eb9e9b8cde282a9fe6a42dd4681319bfb63f121b8a8ee9439c6f4107e58a46f7"
+"checksum serde 1.0.82 (registry+https://github.com/rust-lang/crates.io-index)" = "6fa52f19aee12441d5ad11c9a00459122bd8f98707cadf9778c540674f1935b6"
+"checksum serde_derive 1.0.82 (registry+https://github.com/rust-lang/crates.io-index)" = "96a7f9496ac65a2db5929afa087b54f8fc5008dcfbe48a8874ed20049b0d6154"
+"checksum serde_json 1.0.33 (registry+https://github.com/rust-lang/crates.io-index)" = "c37ccd6be3ed1fdf419ee848f7c758eb31b054d7cd3ae3600e3bae0adf569811"
+"checksum serde_yaml 0.8.8 (registry+https://github.com/rust-lang/crates.io-index)" = "0887a8e097a69559b56aa2526bf7aff7c3048cf627dff781f0b56a6001534593"
 "checksum strsim 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "bb4f380125926a99e52bc279241539c018323fab05ad6368b56f93d9369ff550"
-"checksum syn 0.14.8 (registry+https://github.com/rust-lang/crates.io-index)" = "b7bfcbb0c068d0f642a0ffbd5c604965a360a61f99e8add013cef23a838614f3"
+"checksum syn 0.15.22 (registry+https://github.com/rust-lang/crates.io-index)" = "ae8b29eb5210bc5cf63ed6149cbf9adfc82ac0be023d8735c176ee74a2db4da7"
 "checksum termion 1.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "689a3bdfaab439fd92bc87df5c4c78417d3cbe537487274e9b0b2dce76e92096"
 "checksum textwrap 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)" = "307686869c93e71f94da64286f9a9524c0f308a9e1c87a583de8e9c9039ad3f6"
 "checksum unicode-width 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "882386231c45df4700b275c7ff55b6f3698780a650026380e72dabe76fa46526"
 "checksum unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "fc72304796d0818e357ead4e000d19c9c174ab23dc11093ac919054d20a6a7fc"
 "checksum unreachable 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "382810877fe448991dfc7f0dd6e3ae5d58088fd0ea5e35189655f84e6814fa56"
 "checksum vec_map 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)" = "05c78687fb1a80548ae3250346c3db86a80a7cdd77bda190189f2d0a0987c81a"
+"checksum version_check 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "914b1a6776c4c929a602fafd8bc742e06365d4bcbe48c30f9cca5824f70dc9dd"
 "checksum void 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"
-"checksum winapi 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)" = "773ef9dcc5f24b7d850d0ff101e542ff24c3b090a9768e03ff889fdef41f00fd"
+"checksum winapi 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)" = "92c1eb33641e276cfa214a0522acad57be5c56b10cb348b3c5117db75f3ac4b0"
 "checksum winapi-i686-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
 "checksum winapi-x86_64-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
-"checksum yaml-rust 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "57ab38ee1a4a266ed033496cf9af1828d8d6e6c1cfa5f643a2809effcae4d628"
+"checksum yaml-rust 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "95acf0db5515d07da9965ec0e0ba6cc2d825e2caeb7303b66ca441729801254e"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,13 +2,14 @@
 name = "lustre_collector"
 version = "0.1.0"
 authors = ["IML Team <iml@whamcloud.com>"]
+edition = "2018"
 
 [dependencies]
-combine = "3.5.2"
+combine = "3.6"
 serde = "1.0"
 serde_derive = "1.0"
 serde_json = "1.0"
-serde_yaml = "0.8.4"
+serde_yaml = "0.8"
 clap = "2.32.0"
 
 [dependencies.error-chain]

--- a/src/base_parsers.rs
+++ b/src/base_parsers.rs
@@ -3,15 +3,16 @@
 // license that can be found in the LICENSE file.
 
 use combine::{
+    attempt,
     char::{alpha_num, digit, newline, string},
     error::ParseError,
     many1, one_of,
     parser::repeat::take_until,
     stream::Stream,
-    token, try, unexpected, value, Parser,
+    token, unexpected, value, Parser,
 };
 
-use types::{Param, Target};
+use crate::types::{Param, Target};
 
 pub fn period<I>() -> impl Parser<Input = I, Output = char>
 where
@@ -69,7 +70,7 @@ where
     I: Stream<Item = char>,
     I::Error: ParseError<I::Item, I::Range, I::Position>,
 {
-    try(word().then(move |y| {
+    attempt(word().then(move |y| {
         for &x in xs {
             if x == y {
                 return unexpected(x).map(|_| "".to_string()).right();
@@ -85,7 +86,7 @@ where
     I: Stream<Item = char>,
     I::Error: ParseError<I::Item, I::Range, I::Position>,
 {
-    try(string(x).skip(token('=')))
+    attempt(string(x).skip(token('=')))
         .map(|x| Param(x.to_string()))
         .message("while getting param")
 }
@@ -93,8 +94,8 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::types::Param;
     use combine::stream::state::{SourcePosition, State};
-    use types::Param;
 
     #[test]
     fn test_param() {

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,9 +2,8 @@
 // Use of this source code is governed by a MIT-style
 // license that can be found in the LICENSE file.
 
-#![allow(unknown_lints)]
-#![warn(clippy)]
-#![cfg_attr(feature = "cargo-clippy", allow(let_and_return))]
+#![warn(clippy::all)]
+#![cfg_attr(feature = "cargo-clippy", allow(clippy::let_and_return))]
 // `error_chain!` can recurse deeply
 #![recursion_limit = "1024"]
 
@@ -20,11 +19,6 @@ extern crate clap;
 
 #[macro_use]
 extern crate serde_derive;
-
-extern crate combine;
-extern crate serde;
-extern crate serde_json;
-extern crate serde_yaml;
 
 use clap::{App, Arg};
 
@@ -45,12 +39,12 @@ use std::process::Command;
 
 mod errors {
     // Create the Error, ErrorKind, ResultExt, and Result types
-    error_chain!{}
+    error_chain! {}
 }
 
-use errors::*;
+use self::errors::*;
 
-arg_enum!{
+arg_enum! {
     #[derive(PartialEq, Debug)]
     enum Format {
         Json,
@@ -76,7 +70,8 @@ fn main() {
                 .default_value(&variants[0])
                 .help("Sets the output formatting")
                 .takes_value(true),
-        ).get_matches();
+        )
+        .get_matches();
 
     let format = value_t!(matches, "format", Format).unwrap_or_else(|e| e.exit());
 

--- a/src/mgs/mgs_parser.rs
+++ b/src/mgs/mgs_parser.rs
@@ -2,16 +2,18 @@
 // Use of this source code is governed by a MIT-style
 // license that can be found in the LICENSE file.
 
-use base_parsers::{digits, param, period, target};
-use stats_parser::stats;
-use types::{Param, Record, Stat, Target, TargetStat, TargetStats, TargetVariant};
+use crate::{
+    base_parsers::{digits, param, period, target},
+    stats_parser::stats,
+    types::{Param, Record, Stat, Target, TargetStat, TargetStats, TargetVariant},
+};
 
 use combine::{
-    choice,
+    attempt, choice,
     error::{ParseError, StreamError},
     parser::char::{newline, string},
     stream::{Stream, StreamErrorFor},
-    try, Parser,
+    Parser,
 };
 
 pub const STATS: &str = "stats";
@@ -26,9 +28,9 @@ pub fn params() -> Vec<String> {
         format!("mgs.*.mgs.{}", THREADS_MIN),
         format!("mgs.*.{}", NUM_EXPORTS),
     ]
-        .into_iter()
-        .map(|x| x.to_owned())
-        .collect::<Vec<_>>()
+    .into_iter()
+    .map(|x| x.to_owned())
+    .collect::<Vec<_>>()
 }
 
 #[derive(Debug)]
@@ -45,7 +47,10 @@ where
     I: Stream<Item = char>,
     I::Error: ParseError<I::Item, I::Range, I::Position>,
 {
-    (try(string("mgs")).skip(period()), target().skip(period()))
+    (
+        attempt(string("mgs")).skip(period()),
+        target().skip(period()),
+    )
         .map(|(_, x)| x)
         .message("while parsing target_name")
 }
@@ -117,6 +122,7 @@ where
             };
 
             r
-        }).map(Record::Target)
+        })
+        .map(Record::Target)
         .message("while parsing mgs params")
 }

--- a/src/oss/brw_stats_parser.rs
+++ b/src/oss/brw_stats_parser.rs
@@ -2,13 +2,15 @@
 // Use of this source code is governed by a MIT-style
 // license that can be found in the LICENSE file.
 
-use base_parsers::{digits, string_to, till_newline, word};
+use crate::{
+    base_parsers::{digits, string_to, till_newline, word},
+    snapshot_time::snapshot_time,
+    types::{BrwStats, BrwStatsBucket},
+};
 use combine::error::ParseError;
 use combine::parser::char::{newline, spaces, string};
 use combine::stream::Stream;
-use combine::{choice, many, many1, one_of, optional, token, try, Parser};
-use snapshot_time::snapshot_time;
-use types::{BrwStats, BrwStatsBucket};
+use combine::{attempt, choice, many, many1, one_of, optional, token, Parser};
 
 fn human_to_bytes((x, y): (u64, Option<char>)) -> u64 {
     let mult = match y {
@@ -44,13 +46,13 @@ where
     I::Error: ParseError<I::Item, I::Range, I::Position>,
 {
     let keys = choice([
-        try(string_to("pages per bulk r/w", "pages")),
-        try(string_to("discontiguous pages", "discont_pages")),
-        try(string_to("discontiguous blocks", "discont_blocks")),
-        try(string_to("disk fragmented I/Os", "dio_frags")),
-        try(string_to("disk I/Os in flight", "rpc_hist")),
-        try(string_to("I/O time (1/1000s)", "io_time")),
-        try(string_to("disk I/O size", "disk_iosize")),
+        attempt(string_to("pages per bulk r/w", "pages")),
+        attempt(string_to("discontiguous pages", "discont_pages")),
+        attempt(string_to("discontiguous blocks", "discont_blocks")),
+        attempt(string_to("disk fragmented I/Os", "dio_frags")),
+        attempt(string_to("disk I/Os in flight", "rpc_hist")),
+        attempt(string_to("I/O time (1/1000s)", "io_time")),
+        attempt(string_to("disk I/O size", "disk_iosize")),
     ]);
 
     (keys.skip(spaces()), word().skip(till_newline())).map(|(name, unit)| BrwStats {

--- a/src/oss/job_stats.rs
+++ b/src/oss/job_stats.rs
@@ -3,6 +3,7 @@
 // license that can be found in the LICENSE file.
 
 use combine::{
+    attempt,
     error::{ParseError, StreamError},
     optional,
     parser::{
@@ -10,12 +11,12 @@ use combine::{
         repeat::take_until,
     },
     stream::{Stream, StreamErrorFor},
-    try, Parser,
+    Parser,
 };
 
 use serde_yaml;
 
-use types::{JobStatOst, JobStatsOst};
+use crate::types::{JobStatOst, JobStatsOst};
 
 pub fn parse<I>() -> impl Parser<Input = I, Output = Option<Vec<JobStatOst>>>
 where
@@ -24,7 +25,7 @@ where
 {
     (
         optional(newline()), // If Jobstats are present, the whole yaml blob will be on a newline
-        take_until(try((newline(), alpha_num()))),
+        take_until(attempt((newline(), alpha_num()))),
     )
         .skip(newline())
         .and_then(|(_, x): (_, String)| {
@@ -37,8 +38,8 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::types::{BytesStat, ReqsStat};
     use serde_yaml;
-    use types::{BytesStat, ReqsStat};
 
     #[test]
     fn test_yaml_deserialize() {

--- a/src/oss/ldlm_parser.rs
+++ b/src/oss/ldlm_parser.rs
@@ -10,8 +10,10 @@ use combine::{
     Parser,
 };
 
-use base_parsers::{digits, param, period, target};
-use types::{Param, Record, Target, TargetStat, TargetStats, TargetVariant};
+use crate::{
+    base_parsers::{digits, param, period, target},
+    types::{Param, Record, Target, TargetStat, TargetStats, TargetVariant},
+};
 
 pub const CONTENDED_LOCKS: &str = "contended_locks";
 pub const CONTENTION_SECONDS: &str = "contention_seconds";
@@ -67,7 +69,8 @@ where
                 [y, _] => Ok(Target(y.to_string())),
                 _ => Err(StreamErrorFor::<I>::expected_static_message("_UUID")),
             }
-        }).skip(period())
+        })
+        .skip(period())
         .message("while parsing lock_namespaces")
 }
 
@@ -174,7 +177,8 @@ where
             _ => Err(StreamErrorFor::<I>::unexpected_static_message(
                 "Unexpected top-level param",
             )),
-        }).map(Record::Target)
+        })
+        .map(Record::Target)
         .message("while parsing ldlm")
 }
 

--- a/src/oss/obdfilter_parser.rs
+++ b/src/oss/obdfilter_parser.rs
@@ -10,12 +10,14 @@ use combine::{
     Parser,
 };
 
-use base_parsers::{digits, param, period, target, till_newline};
-use oss::brw_stats_parser::brw_stats;
-use oss::job_stats;
-use stats_parser::stats;
-use types::{
-    BrwStats, JobStatOst, Param, Record, Stat, Target, TargetStat, TargetStats, TargetVariant,
+use crate::{
+    base_parsers::{digits, param, period, target, till_newline},
+    oss::brw_stats_parser::brw_stats,
+    oss::job_stats,
+    stats_parser::stats,
+    types::{
+        BrwStats, JobStatOst, Param, Record, Stat, Target, TargetStat, TargetStats, TargetVariant,
+    },
 };
 
 pub const JOBSTATS: &str = "job_stats";
@@ -152,7 +154,8 @@ where
             param(TOT_PENDING),
             digits().skip(newline()).map(ObdfilterStat::TotPending),
         ),
-    )).message("while parsing obdfilter")
+    ))
+    .message("while parsing obdfilter")
 }
 
 pub fn parse<I>() -> impl Parser<Input = I, Output = Record>
@@ -247,7 +250,8 @@ where
                 )),
             };
             r
-        }).map(Record::Target)
+        })
+        .map(Record::Target)
         .message("while parsing obdfilter")
 }
 

--- a/src/oss/oss_parser.rs
+++ b/src/oss/oss_parser.rs
@@ -2,9 +2,11 @@
 // Use of this source code is governed by a MIT-style
 // license that can be found in the LICENSE file.
 
+use crate::{
+    oss::{ldlm_parser, obdfilter_parser},
+    types::Record,
+};
 use combine::{choice, error::ParseError, Parser, Stream};
-use oss::{ldlm_parser, obdfilter_parser};
-use types::Record;
 
 pub fn params() -> Vec<String> {
     let mut a = obdfilter_parser::obd_params();
@@ -25,12 +27,12 @@ where
 mod tests {
 
     use super::*;
-    use combine::many;
-    use combine::stream::state::{SourcePosition, State};
-    use types::{
+    use crate::types::{
         BrwStats, BrwStatsBucket, Param, Record, Stat, Target, TargetStat, TargetStats,
         TargetVariant,
     };
+    use combine::many;
+    use combine::stream::state::{SourcePosition, State};
 
     #[test]
     fn test_params() {

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -2,12 +2,8 @@
 // Use of this source code is governed by a MIT-style
 // license that can be found in the LICENSE file.
 
-use mgs::mgs_parser;
-use oss::oss_parser;
-use top_level_parser;
-
+use crate::{mgs::mgs_parser, oss::oss_parser, top_level_parser, types::Record};
 use combine::{choice, error::ParseError, many, Parser, Stream};
-use types::Record;
 
 pub fn params() -> Vec<String> {
     let mut a = top_level_parser::top_level_params();

--- a/src/snapshot_time.rs
+++ b/src/snapshot_time.rs
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a MIT-style
 // license that can be found in the LICENSE file.
 
-use base_parsers::{digits, till_newline};
+use crate::base_parsers::{digits, till_newline};
 use combine::error::ParseError;
 use combine::parser::char::{spaces, string};
 use combine::stream::Stream;

--- a/src/stats_parser.rs
+++ b/src/stats_parser.rs
@@ -14,9 +14,11 @@ use combine::{
     token, Parser,
 };
 
-use base_parsers::{digits, not_words, word};
-use snapshot_time::snapshot_time;
-use types::Stat;
+use crate::{
+    base_parsers::{digits, not_words, word},
+    snapshot_time::snapshot_time,
+    types::Stat,
+};
 
 fn name_count_units<I>() -> impl Parser<Input = I, Output = (String, u64, String)>
 where

--- a/src/top_level_parser.rs
+++ b/src/top_level_parser.rs
@@ -2,7 +2,6 @@
 // Use of this source code is governed by a MIT-style
 // license that can be found in the LICENSE file.
 
-use base_parsers::{digits, param, word};
 use combine::{
     choice,
     error::{ParseError, StreamError},
@@ -11,7 +10,10 @@ use combine::{
     Parser,
 };
 
-use types::{HostStat, HostStats, Param, Record};
+use crate::{
+    base_parsers::{digits, param, word},
+    types::{HostStat, HostStats, Param, Record},
+};
 
 pub const MEMUSED_MAX: &str = "memused_max";
 pub const MEMUSED: &str = "memused";
@@ -44,7 +46,8 @@ where
         (param(MEMUSED_MAX), digits().map(TopLevelStat::MemusedMax)),
         (param(LNET_MEMUSED), digits().map(TopLevelStat::LnetMemused)),
         (param(HEALTH_CHECK), word().map(TopLevelStat::HealthCheck)),
-    )).skip(newline())
+    ))
+    .skip(newline())
 }
 
 pub fn parse<I>() -> impl Parser<Input = I, Output = Record>
@@ -72,7 +75,8 @@ where
             };
 
             r
-        }).map(Record::Host)
+        })
+        .map(Record::Host)
         .message("while parsing top_level_param")
 }
 
@@ -80,8 +84,8 @@ where
 mod tests {
 
     use super::*;
+    use crate::types::{HostStat, HostStats, Param};
     use combine::stream::state::{SourcePosition, State};
-    use types::{HostStat, HostStats, Param};
 
     #[test]
     fn test_params() {


### PR DESCRIPTION
Update repo to use 2018 edition of Rust.

Signed-off-by: Joe Grund <jgrund@whamcloud.io>