### PR TITLE
Add Deserialize trait to types

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -151,7 +151,7 @@ checksum = "ae91b68aebc4ddb91978b11a1b02ddd8602a05ec19002801c5666000e05e0f83"
 
 [[package]]
 name = "lustre_collector"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "clap",
  "combine",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lustre_collector"
-version = "0.2.1"
+version = "0.2.2"
 license = "MIT"
 description = "Scrapes Lustre stats and aggregates into JSON or YAML"
 authors = ["IML Team <iml@whamcloud.com>"]
@@ -9,7 +9,7 @@ edition = "2018"
 [dependencies]
 combine = "4.0.1"
 serde = { version = "1", features = ["derive"] }
-serde_json = "1"
+serde_json = "1.0"
 serde_yaml = "0.8"
 clap = "2.33"
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # Lustre Collector
 
+![rust](https://github.com/whamcloud/lustre-collector/workflows/rust/badge.svg?branch=master)
+
+![Crates.io](https://img.shields.io/crates/v/lustre_collector) ![docs.rs](https://docs.rs/lustre_collector/badge.svg?version=0.2.2)
+
 This repo provides a parsed representation of common Lustre statistics.
 
 It is provided as a standalone binary that can be called to retrieve stats in the desired output (Currently either JSON | YAML).

--- a/lustre_collector.spec
+++ b/lustre_collector.spec
@@ -1,5 +1,5 @@
 Name: lustre_collector
-Version: 0.2.1
+Version: 0.2.2
 # Release Start
 Release: 1%{?dist}
 # Release End

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,6 +18,7 @@ pub use crate::error::LustreCollectorError;
 use crate::types::Record;
 use combine::Parser;
 use std::{io, str};
+pub use types::*;
 
 pub fn parse_lctl_output(lctl_output: &[u8]) -> Result<Vec<Record>, LustreCollectorError> {
     let mut lctl_stats = str::from_utf8(lctl_output)?;

--- a/src/types.rs
+++ b/src/types.rs
@@ -2,15 +2,15 @@
 // Use of this source code is governed by a MIT-style
 // license that can be found in the LICENSE file.
 
-#[derive(Debug, PartialEq, serde::Serialize)]
+#[derive(Debug, PartialEq, serde::Serialize, serde::Deserialize)]
 /// The hostname cooresponding to these stats.
 pub struct Host(pub String);
 
-#[derive(Debug, PartialEq, serde::Serialize)]
+#[derive(Debug, PartialEq, serde::Serialize, serde::Deserialize)]
 /// The Lustre target cooresponding to these stats.
 pub struct Target(pub String);
 
-#[derive(Debug, PartialEq, serde::Serialize)]
+#[derive(Debug, PartialEq, serde::Serialize, serde::Deserialize)]
 /// The name of the stat.
 pub struct Param(pub String);
 
@@ -187,21 +187,21 @@ pub struct Stat {
     pub sumsquare: Option<u64>,
 }
 
-#[derive(PartialEq, Debug, serde::Serialize)]
+#[derive(PartialEq, Debug, serde::Serialize, serde::Deserialize)]
 /// A Stat specific to a host.
 pub struct HostStat<T> {
     pub param: Param,
     pub value: T,
 }
 
-#[derive(PartialEq, Debug, serde::Serialize)]
+#[derive(PartialEq, Debug, serde::Serialize, serde::Deserialize)]
 pub enum TargetVariant {
     OST,
     MGT,
     MDT,
 }
 
-#[derive(PartialEq, Debug, serde::Serialize)]
+#[derive(PartialEq, Debug, serde::Serialize, serde::Deserialize)]
 /// Stats specific to a target.
 pub struct TargetStat<T> {
     pub kind: TargetVariant,
@@ -210,7 +210,7 @@ pub struct TargetStat<T> {
     pub value: T,
 }
 
-#[derive(PartialEq, Debug, serde::Serialize)]
+#[derive(PartialEq, Debug, serde::Serialize, serde::Deserialize)]
 /// Stats specific to a LNet Nid.
 pub struct LNetStat<T> {
     pub nid: String,
@@ -218,21 +218,21 @@ pub struct LNetStat<T> {
     pub value: T,
 }
 
-#[derive(PartialEq, Debug, serde::Serialize)]
+#[derive(PartialEq, Debug, serde::Serialize, serde::Deserialize)]
 pub struct BrwStatsBucket {
     pub name: u64,
     pub read: u64,
     pub write: u64,
 }
 
-#[derive(PartialEq, Debug, serde::Serialize)]
+#[derive(PartialEq, Debug, serde::Serialize, serde::Deserialize)]
 pub struct BrwStats {
     pub name: String,
     pub unit: String,
     pub buckets: Vec<BrwStatsBucket>,
 }
 
-#[derive(PartialEq, Debug, serde::Serialize)]
+#[derive(PartialEq, Debug, serde::Serialize, serde::Deserialize)]
 #[serde(untagged)]
 pub enum HostStats {
     MemusedMax(HostStat<u64>),
@@ -242,7 +242,7 @@ pub enum HostStats {
 }
 
 /// The target stats currently collected
-#[derive(PartialEq, Debug, serde::Serialize)]
+#[derive(PartialEq, Debug, serde::Serialize, serde::Deserialize)]
 #[serde(untagged)]
 pub enum TargetStats {
     /// Operations per OST. Read and write data is particularly interesting
@@ -282,7 +282,7 @@ pub enum TargetStats {
     ThreadsStarted(TargetStat<u64>),
 }
 
-#[derive(PartialEq, Debug, serde::Serialize)]
+#[derive(PartialEq, Debug, serde::Serialize, serde::Deserialize)]
 #[serde(untagged)]
 pub enum LNetStats {
     SendCount(LNetStat<i64>),
@@ -290,7 +290,7 @@ pub enum LNetStats {
     DropCount(LNetStat<i64>),
 }
 
-#[derive(PartialEq, Debug, serde::Serialize)]
+#[derive(PartialEq, Debug, serde::Serialize, serde::Deserialize)]
 #[serde(untagged)]
 pub enum Record {
     Host(HostStats),


### PR DESCRIPTION
Add the `Deserialize` trait to types so they
can be deserialized. Also expose types at the top-level
for easier usage.

Signed-off-by: Joe Grund <jgrund@whamcloud.io>