### PR TITLE
Use easy_parse

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -151,7 +151,7 @@ checksum = "ae91b68aebc4ddb91978b11a1b02ddd8602a05ec19002801c5666000e05e0f83"
 
 [[package]]
 name = "lustre_collector"
-version = "0.2.5"
+version = "0.2.6"
 dependencies = [
  "clap",
  "combine",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lustre_collector"
-version = "0.2.5"
+version = "0.2.6"
 license = "MIT"
 description = "Scrapes Lustre stats and aggregates into JSON or YAML"
 authors = ["IML Team <iml@whamcloud.com>"]

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ![rust](https://github.com/whamcloud/lustre-collector/workflows/rust/badge.svg?branch=master)
 
-![Crates.io](https://img.shields.io/crates/v/lustre_collector) ![docs.rs](https://docs.rs/lustre_collector/badge.svg?version=0.2.5)
+![Crates.io](https://img.shields.io/crates/v/lustre_collector) ![docs.rs](https://docs.rs/lustre_collector/badge.svg?version=0.2.6)
 
 This repo provides a parsed representation of common Lustre statistics.
 

--- a/lustre_collector.spec
+++ b/lustre_collector.spec
@@ -1,5 +1,5 @@
 Name: lustre_collector
-Version: 0.2.5
+Version: 0.2.6
 # Release Start
 Release: 1%{?dist}
 # Release End

--- a/src/error.rs
+++ b/src/error.rs
@@ -11,6 +11,7 @@ pub enum LustreCollectorError {
     SerdeJsonError(serde_json::error::Error),
     SerdeYamlError(serde_yaml::Error),
     StringStreamError(StringStreamError),
+    CombineEasyError(combine::stream::easy::Errors<char, &'static str, usize>),
     Utf8Error(str::Utf8Error),
 }
 
@@ -21,6 +22,7 @@ impl std::fmt::Display for LustreCollectorError {
             LustreCollectorError::SerdeJsonError(ref err) => write!(f, "{}", err),
             LustreCollectorError::SerdeYamlError(ref err) => write!(f, "{}", err),
             LustreCollectorError::StringStreamError(ref err) => write!(f, "{}", err),
+            LustreCollectorError::CombineEasyError(ref err) => write!(f, "{}", err),
             LustreCollectorError::Utf8Error(ref err) => write!(f, "{}", err),
         }
     }
@@ -34,6 +36,7 @@ impl std::error::Error for LustreCollectorError {
             LustreCollectorError::SerdeYamlError(ref err) => Some(err),
             LustreCollectorError::StringStreamError(ref err) => Some(err),
             LustreCollectorError::Utf8Error(ref err) => Some(err),
+            LustreCollectorError::CombineEasyError(ref err) => Some(err),
         }
     }
 }
@@ -65,5 +68,11 @@ impl From<str::Utf8Error> for LustreCollectorError {
 impl From<StringStreamError> for LustreCollectorError {
     fn from(err: StringStreamError) -> Self {
         LustreCollectorError::StringStreamError(err)
+    }
+}
+
+impl From<combine::stream::easy::Errors<char, &str, usize>> for LustreCollectorError {
+    fn from(err: combine::stream::easy::Errors<char, &str, usize>) -> Self {
+        LustreCollectorError::CombineEasyError(err.map_range(|_| ""))
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,16 +15,18 @@ mod top_level_parser;
 pub mod types;
 
 pub use crate::error::LustreCollectorError;
-use combine::Parser;
+use combine::parser::EasyParser;
 use std::{io, str};
 pub use types::*;
 
 pub fn parse_lctl_output(lctl_output: &[u8]) -> Result<Vec<Record>, LustreCollectorError> {
-    let mut lctl_stats = str::from_utf8(lctl_output)?;
+    let lctl_stats = str::from_utf8(lctl_output)?;
 
-    let (lctl_record, state) = parser::parse().parse(&mut lctl_stats)?;
+    let (lctl_record, state) = parser::parse()
+        .easy_parse(lctl_stats)
+        .map_err(|err| err.map_position(|p| p.translate_position(lctl_stats)))?;
 
-    if state != &"" {
+    if state != "" {
         return Err(io::Error::new(
             io::ErrorKind::InvalidInput,
             format!("Content left in input buffer: {}", state),

--- a/src/main.rs
+++ b/src/main.rs
@@ -67,18 +67,18 @@ fn main() {
     let lnetctl_stats =
         str::from_utf8(&lnetctl_output.stdout).expect("while converting lnetctl stdout from utf8");
 
-    let lnet_record = parse_lnetctl_output(lnetctl_stats).expect("while parsing lnetctl stats");
+    let mut lnet_record = parse_lnetctl_output(lnetctl_stats).expect("while parsing lnetctl stats");
 
-    let lctl_record = handle.join().unwrap().unwrap();
+    let mut lctl_record = handle.join().unwrap().unwrap();
 
-    let record = vec![lctl_record, lnet_record];
+    lctl_record.append(&mut lnet_record);
 
     let r = match format {
         Format::Json => {
-            serde_json::to_string(&record).map_err(LustreCollectorError::SerdeJsonError)
+            serde_json::to_string(&lctl_record).map_err(LustreCollectorError::SerdeJsonError)
         }
         Format::Yaml => {
-            serde_yaml::to_string(&record).map_err(LustreCollectorError::SerdeYamlError)
+            serde_yaml::to_string(&lctl_record).map_err(LustreCollectorError::SerdeYamlError)
         }
     };
 


### PR DESCRIPTION
use easy_parse instead of parse so errors contain useful information
about parsing.

Signed-off-by: Joe Grund <jgrund@whamcloud.io>