### PR TITLE
Add parsers for node stats

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -104,9 +104,9 @@ checksum = "a357d28ed41a50f9c765dbfe56cbc04a64e53e5fc58ba79fbc34c10ef3df831f"
 
 [[package]]
 name = "hermit-abi"
-version = "0.1.6"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eff2656d88f158ce120947499e971d743c05dbcbed62e5bd2f38f1698bbc3772"
+checksum = "e2c55f143919fbc0bc77e427fe2d74cf23786d7c1875666f2fde3ac3c659bb67"
 dependencies = [
  "libc",
 ]
@@ -151,7 +151,7 @@ checksum = "ae91b68aebc4ddb91978b11a1b02ddd8602a05ec19002801c5666000e05e0f83"
 
 [[package]]
 name = "lustre_collector"
-version = "0.2.8"
+version = "0.2.9"
 dependencies = [
  "clap",
  "combine",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lustre_collector"
-version = "0.2.8"
+version = "0.2.9"
 license = "MIT"
 description = "Scrapes Lustre stats and aggregates into JSON or YAML"
 authors = ["IML Team <iml@whamcloud.com>"]

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ![rust](https://github.com/whamcloud/lustre-collector/workflows/rust/badge.svg?branch=master)
 
-![Crates.io](https://img.shields.io/crates/v/lustre_collector) ![docs.rs](https://docs.rs/lustre_collector/badge.svg?version=0.2.8)
+![Crates.io](https://img.shields.io/crates/v/lustre_collector) ![docs.rs](https://docs.rs/lustre_collector/badge.svg?version=0.2.9)
 
 This repo provides a parsed representation of common Lustre statistics.
 

--- a/lustre_collector.spec
+++ b/lustre_collector.spec
@@ -1,5 +1,5 @@
 Name: lustre_collector
-Version: 0.2.8
+Version: 0.2.9
 # Release Start
 Release: 1%{?dist}
 # Release End

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,6 +7,7 @@ pub mod error;
 mod lnetctl_parser;
 mod mds;
 mod mgs;
+mod node_stats_parsers;
 mod oss;
 pub mod parser;
 mod snapshot_time;
@@ -16,6 +17,8 @@ pub mod types;
 
 pub use crate::error::LustreCollectorError;
 use combine::parser::EasyParser;
+pub use lnetctl_parser::parse as parse_lnetctl_output;
+pub use node_stats_parsers::{parse_cpustats_output, parse_meminfo_output};
 use std::{io, str};
 pub use types::*;
 
@@ -36,5 +39,3 @@ pub fn parse_lctl_output(lctl_output: &[u8]) -> Result<Vec<Record>, LustreCollec
 
     Ok(lctl_record)
 }
-
-pub use lnetctl_parser::parse as parse_lnetctl_output;

--- a/src/node_stats_parsers.rs
+++ b/src/node_stats_parsers.rs
@@ -1,0 +1,220 @@
+// Copyright (c) 2020 DDN. All rights reserved.
+// Use of this source code is governed by a MIT-style
+// license that can be found in the LICENSE file.
+
+use crate::{
+    base_parsers::{digits, string_to, till_newline},
+    types::{NodeStat, Param},
+    LustreCollectorError, NodeStats,
+};
+use combine::{
+    attempt, choice,
+    error::ParseError,
+    parser::EasyParser,
+    parser::{
+        char::{newline, spaces, string},
+        repeat::take_until,
+    },
+    sep_end_by,
+    stream::Stream,
+    token, Parser,
+};
+use std::io;
+
+pub fn parse_cpustats_output(output: &[u8]) -> Result<Vec<NodeStats>, LustreCollectorError> {
+    let output = std::str::from_utf8(output)?;
+
+    let (stats, state) = parse_cpustats()
+        .easy_parse(output)
+        .map_err(|err| err.map_position(|p| p.translate_position(output)))?;
+
+    if state != "" {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            format!("Content left in input buffer: {}", state),
+        )
+        .into());
+    }
+
+    Ok(stats)
+}
+
+fn parse_cpustats<I>() -> impl Parser<I, Output = Vec<NodeStats>>
+where
+    I: Stream<Token = char>,
+    I::Error: ParseError<I::Token, I::Range, I::Position>,
+{
+    (string("cpu").skip(spaces()), sep_end_by(digits(), spaces())).map(|(_, xs): (_, Vec<_>)| {
+        vec![
+            NodeStats::CpuTotal(NodeStat {
+                param: Param("cpu_total".into()),
+                value: xs.iter().take(6).sum(),
+            }),
+            NodeStats::CpuUser(NodeStat {
+                param: Param("cpu_user".into()),
+                value: xs.iter().take(1).sum(),
+            }),
+            NodeStats::CpuIowait(NodeStat {
+                param: Param("cpu_iowait".into()),
+                value: xs.get(4).cloned().unwrap_or_default(),
+            }),
+            NodeStats::CpuSystem(NodeStat {
+                param: Param("cpu_system".into()),
+                value: xs
+                    .get(2)
+                    .and_then(|x| {
+                        let y = xs.get(5)?;
+
+                        Some(x + y)
+                    })
+                    .unwrap_or_default(),
+            }),
+        ]
+    })
+}
+
+pub fn parse_meminfo_output(output: &[u8]) -> Result<Vec<NodeStats>, LustreCollectorError> {
+    let output = std::str::from_utf8(output)?;
+
+    let (mem_stats, state) = parse_meminfo()
+        .easy_parse(output)
+        .map_err(|err| err.map_position(|p| p.translate_position(output)))?;
+
+    if state != "" {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            format!("Content left in input buffer: {}", state),
+        )
+        .into());
+    }
+
+    Ok(mem_stats)
+}
+
+fn parse_meminfo<I>() -> impl Parser<I, Output = Vec<NodeStats>>
+where
+    I: Stream<Token = char>,
+    I::Error: ParseError<I::Token, I::Range, I::Position>,
+{
+    sep_end_by(
+        choice((
+            parse_meminfo_line().map(Some),
+            (
+                take_until::<String, _, _>(token(':')),
+                token(':').skip(spaces()),
+                digits().skip(till_newline()),
+            )
+                .map(|_| None),
+        )),
+        newline(),
+    )
+    .map(|xs: Vec<_>| xs.into_iter().filter_map(|x| x).collect())
+}
+
+fn parse_meminfo_line<I>() -> impl Parser<I, Output = NodeStats>
+where
+    I: Stream<Token = char>,
+    I::Error: ParseError<I::Token, I::Range, I::Position>,
+{
+    choice((
+        attempt(consume_line("MemTotal", "mem_total").map(NodeStats::MemTotal)),
+        attempt(consume_line("MemFree", "mem_free").map(NodeStats::MemFree)),
+        attempt(consume_line("SwapTotal", "swap_total").map(NodeStats::SwapTotal)),
+        attempt(consume_line("SwapFree", "swap_free").map(NodeStats::SwapFree)),
+    ))
+}
+
+fn consume_line<I>(name: &'static str, to: &'static str) -> impl Parser<I, Output = NodeStat<u64>>
+where
+    I: Stream<Token = char>,
+    I::Error: ParseError<I::Token, I::Range, I::Position>,
+{
+    (
+        string_to(name, to),
+        token(':').skip(spaces()),
+        digits().skip(till_newline()),
+    )
+        .map(|(param, _, value)| NodeStat {
+            param: Param(param),
+            value,
+        })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use combine::parser::EasyParser;
+    use insta::assert_debug_snapshot;
+
+    const PROC_MEMINFO: &'static str = r#"MemTotal:        5943788 kB
+MemFree:         4420248 kB
+MemAvailable:    4707828 kB
+Buffers:            5196 kB
+Cached:           548160 kB
+SwapCached:            0 kB
+Active:           517648 kB
+Inactive:         181844 kB
+Active(anon):     190448 kB
+Inactive(anon):    45888 kB
+Active(file):     327200 kB
+Inactive(file):   135956 kB
+Unevictable:       84644 kB
+Mlocked:           84644 kB
+SwapTotal:       2097148 kB
+SwapFree:        2097148 kB
+Dirty:                28 kB
+Writeback:             0 kB
+AnonPages:        230740 kB
+Mapped:           117352 kB
+Shmem:             80044 kB
+Slab:             141992 kB
+SReclaimable:      71472 kB
+SUnreclaim:        70520 kB
+KernelStack:        7216 kB
+PageTables:         9072 kB
+NFS_Unstable:          0 kB
+Bounce:                0 kB
+WritebackTmp:          0 kB
+CommitLimit:     5069040 kB
+Committed_AS:     720820 kB
+VmallocTotal:   34359738367 kB
+VmallocUsed:      153492 kB
+VmallocChunk:   34359496972 kB
+HardwareCorrupted:     0 kB
+AnonHugePages:     38912 kB
+CmaTotal:              0 kB
+CmaFree:               0 kB
+HugePages_Total:       0
+HugePages_Free:        0
+HugePages_Rsvd:        0
+HugePages_Surp:        0
+Hugepagesize:       2048 kB
+DirectMap4k:      245696 kB
+DirectMap2M:     6045696 kB
+"#;
+
+    #[test]
+    fn test_parse_meminfo_line() {
+        let x = r#"MemTotal:        5943788 kB
+"#;
+
+        assert_debug_snapshot!(parse_meminfo_line().parse(x));
+    }
+
+    #[test]
+    fn test_parse_meminfo() {
+        assert_debug_snapshot!(parse_meminfo().easy_parse(PROC_MEMINFO));
+    }
+
+    #[test]
+    fn test_empty_input() {
+        assert_debug_snapshot!(parse_meminfo().easy_parse(""));
+    }
+
+    #[test]
+    fn test_cpu_stats() {
+        let x = "cpu  370338 12 481420 140010546 6313 0 39674 0 0 0";
+
+        assert_debug_snapshot!(parse_cpustats().easy_parse(x));
+    }
+}

--- a/src/snapshots/lustre_collector__node_stats_parsers__tests__cpu_stats.snap
+++ b/src/snapshots/lustre_collector__node_stats_parsers__tests__cpu_stats.snap
@@ -1,0 +1,43 @@
+---
+source: src/node_stats_parsers.rs
+expression: parse_cpustats().easy_parse(x)
+---
+Ok(
+    (
+        [
+            CpuTotal(
+                NodeStat {
+                    param: Param(
+                        "cpu_total",
+                    ),
+                    value: 140868629,
+                },
+            ),
+            CpuUser(
+                NodeStat {
+                    param: Param(
+                        "cpu_user",
+                    ),
+                    value: 370338,
+                },
+            ),
+            CpuIowait(
+                NodeStat {
+                    param: Param(
+                        "cpu_iowait",
+                    ),
+                    value: 6313,
+                },
+            ),
+            CpuSystem(
+                NodeStat {
+                    param: Param(
+                        "cpu_system",
+                    ),
+                    value: 481420,
+                },
+            ),
+        ],
+        "",
+    ),
+)

--- a/src/snapshots/lustre_collector__node_stats_parsers__tests__empty_input.snap
+++ b/src/snapshots/lustre_collector__node_stats_parsers__tests__empty_input.snap
@@ -1,0 +1,10 @@
+---
+source: src/node_stats_parsers.rs
+expression: "parse_meminfo().easy_parse(\"\")"
+---
+Ok(
+    (
+        [],
+        "",
+    ),
+)

--- a/src/snapshots/lustre_collector__node_stats_parsers__tests__parse_meminfo.snap
+++ b/src/snapshots/lustre_collector__node_stats_parsers__tests__parse_meminfo.snap
@@ -1,0 +1,43 @@
+---
+source: src/node_stats_parsers.rs
+expression: parse_meminfo().easy_parse(meminfo)
+---
+Ok(
+    (
+        [
+            MemTotal(
+                NodeStat {
+                    param: Param(
+                        "mem_total",
+                    ),
+                    value: 5943788,
+                },
+            ),
+            MemFree(
+                NodeStat {
+                    param: Param(
+                        "mem_free",
+                    ),
+                    value: 4420248,
+                },
+            ),
+            SwapTotal(
+                NodeStat {
+                    param: Param(
+                        "swap_total",
+                    ),
+                    value: 2097148,
+                },
+            ),
+            SwapFree(
+                NodeStat {
+                    param: Param(
+                        "swap_free",
+                    ),
+                    value: 2097148,
+                },
+            ),
+        ],
+        "",
+    ),
+)

--- a/src/snapshots/lustre_collector__node_stats_parsers__tests__parse_meminfo_line.snap
+++ b/src/snapshots/lustre_collector__node_stats_parsers__tests__parse_meminfo_line.snap
@@ -1,0 +1,17 @@
+---
+source: src/node_stats_parsers.rs
+expression: parse_meminfo_line().parse(x)
+---
+Ok(
+    (
+        MemTotal(
+            NodeStat {
+                param: Param(
+                    "mem_total",
+                ),
+                value: 5943788,
+            },
+        ),
+        "\n",
+    ),
+)

--- a/src/types.rs
+++ b/src/types.rs
@@ -276,6 +276,25 @@ pub enum HostStats {
     HealthCheck(HostStat<String>),
 }
 
+/// A Stat specific to a node.
+#[derive(PartialEq, Debug, serde::Serialize, serde::Deserialize)]
+pub struct NodeStat<T> {
+    pub param: Param,
+    pub value: T,
+}
+/// Top level node stats (not directly Lustre related)
+#[derive(PartialEq, Debug, serde::Serialize, serde::Deserialize)]
+pub enum NodeStats {
+    CpuUser(NodeStat<u64>),
+    CpuSystem(NodeStat<u64>),
+    CpuIowait(NodeStat<u64>),
+    CpuTotal(NodeStat<u64>),
+    MemTotal(NodeStat<u64>),
+    MemFree(NodeStat<u64>),
+    SwapTotal(NodeStat<u64>),
+    SwapFree(NodeStat<u64>),
+}
+
 /// The target stats currently collected
 #[derive(PartialEq, Debug, serde::Serialize, serde::Deserialize)]
 pub enum TargetStats {
@@ -326,6 +345,7 @@ pub enum LNetStats {
 #[derive(PartialEq, Debug, serde::Serialize, serde::Deserialize)]
 pub enum Record {
     Host(HostStats),
-    Target(TargetStats),
     LNetStat(LNetStats),
+    Node(NodeStats),
+    Target(TargetStats),
 }


### PR DESCRIPTION
Add some new parsers for interpreting /proc/meminfo and /proc/stat.

These are not exposed via the cli interface, as they are not really
lustre specific.

Signed-off-by: Joe Grund <jgrund@whamcloud.io>