### PR TITLE
Unify Node returns

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -151,7 +151,7 @@ checksum = "ae91b68aebc4ddb91978b11a1b02ddd8602a05ec19002801c5666000e05e0f83"
 
 [[package]]
 name = "lustre_collector"
-version = "0.2.9"
+version = "0.2.10"
 dependencies = [
  "clap",
  "combine",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lustre_collector"
-version = "0.2.9"
+version = "0.2.10"
 license = "MIT"
 description = "Scrapes Lustre stats and aggregates into JSON or YAML"
 authors = ["IML Team <iml@whamcloud.com>"]

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ![rust](https://github.com/whamcloud/lustre-collector/workflows/rust/badge.svg?branch=master)
 
-![Crates.io](https://img.shields.io/crates/v/lustre_collector) ![docs.rs](https://docs.rs/lustre_collector/badge.svg?version=0.2.9)
+![Crates.io](https://img.shields.io/crates/v/lustre_collector) ![docs.rs](https://docs.rs/lustre_collector/badge.svg?version=0.2.10)
 
 This repo provides a parsed representation of common Lustre statistics.
 

--- a/src/snapshots/lustre_collector__node_stats_parsers__tests__cpu_stats.snap
+++ b/src/snapshots/lustre_collector__node_stats_parsers__tests__cpu_stats.snap
@@ -5,37 +5,45 @@ expression: parse_cpustats().easy_parse(x)
 Ok(
     (
         [
-            CpuTotal(
-                NodeStat {
-                    param: Param(
-                        "cpu_total",
-                    ),
-                    value: 140868629,
-                },
+            Node(
+                CpuTotal(
+                    NodeStat {
+                        param: Param(
+                            "cpu_total",
+                        ),
+                        value: 140868629,
+                    },
+                ),
             ),
-            CpuUser(
-                NodeStat {
-                    param: Param(
-                        "cpu_user",
-                    ),
-                    value: 370338,
-                },
+            Node(
+                CpuUser(
+                    NodeStat {
+                        param: Param(
+                            "cpu_user",
+                        ),
+                        value: 370338,
+                    },
+                ),
             ),
-            CpuIowait(
-                NodeStat {
-                    param: Param(
-                        "cpu_iowait",
-                    ),
-                    value: 6313,
-                },
+            Node(
+                CpuIowait(
+                    NodeStat {
+                        param: Param(
+                            "cpu_iowait",
+                        ),
+                        value: 6313,
+                    },
+                ),
             ),
-            CpuSystem(
-                NodeStat {
-                    param: Param(
-                        "cpu_system",
-                    ),
-                    value: 481420,
-                },
+            Node(
+                CpuSystem(
+                    NodeStat {
+                        param: Param(
+                            "cpu_system",
+                        ),
+                        value: 481420,
+                    },
+                ),
             ),
         ],
         "",

--- a/src/snapshots/lustre_collector__node_stats_parsers__tests__parse_meminfo.snap
+++ b/src/snapshots/lustre_collector__node_stats_parsers__tests__parse_meminfo.snap
@@ -1,41 +1,49 @@
 ---
 source: src/node_stats_parsers.rs
-expression: parse_meminfo().easy_parse(meminfo)
+expression: parse_meminfo().easy_parse(PROC_MEMINFO)
 ---
 Ok(
     (
         [
-            MemTotal(
-                NodeStat {
-                    param: Param(
-                        "mem_total",
-                    ),
-                    value: 5943788,
-                },
+            Node(
+                MemTotal(
+                    NodeStat {
+                        param: Param(
+                            "mem_total",
+                        ),
+                        value: 5943788,
+                    },
+                ),
             ),
-            MemFree(
-                NodeStat {
-                    param: Param(
-                        "mem_free",
-                    ),
-                    value: 4420248,
-                },
+            Node(
+                MemFree(
+                    NodeStat {
+                        param: Param(
+                            "mem_free",
+                        ),
+                        value: 4420248,
+                    },
+                ),
             ),
-            SwapTotal(
-                NodeStat {
-                    param: Param(
-                        "swap_total",
-                    ),
-                    value: 2097148,
-                },
+            Node(
+                SwapTotal(
+                    NodeStat {
+                        param: Param(
+                            "swap_total",
+                        ),
+                        value: 2097148,
+                    },
+                ),
             ),
-            SwapFree(
-                NodeStat {
-                    param: Param(
-                        "swap_free",
-                    ),
-                    value: 2097148,
-                },
+            Node(
+                SwapFree(
+                    NodeStat {
+                        param: Param(
+                            "swap_free",
+                        ),
+                        value: 2097148,
+                    },
+                ),
             ),
         ],
         "",

--- a/src/snapshots/lustre_collector__node_stats_parsers__tests__parse_meminfo_line.snap
+++ b/src/snapshots/lustre_collector__node_stats_parsers__tests__parse_meminfo_line.snap
@@ -4,13 +4,15 @@ expression: parse_meminfo_line().parse(x)
 ---
 Ok(
     (
-        MemTotal(
-            NodeStat {
-                param: Param(
-                    "mem_total",
-                ),
-                value: 5943788,
-            },
+        Node(
+            MemTotal(
+                NodeStat {
+                    param: Param(
+                        "mem_total",
+                    ),
+                    value: 5943788,
+                },
+            ),
         ),
         "\n",
     ),


### PR DESCRIPTION
Info returned from nodestats needs to be unified under the `Record`
enum.

Signed-off-by: Joe Grund <jgrund@whamcloud.io>