### PR TITLE
Implement connected client count

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -63,3 +63,23 @@ jobs:
         with:
           command: clippy
           args: -- -D warnings
+
+  check_rpm_build:
+    name: Check RPM build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v1
+
+      - name: Build rpm
+        uses: ./.github/actions/copr-rust
+        env:
+          SPEC: lustre_collector.spec
+          LOCAL_ONLY: true
+          WORKSPACE: ${{ github.workspace }}
+          RUSTUP_TOOLCHAIN: stable-x86_64-unknown-linux-gnu
+      - name: Archive rpm
+        uses: actions/upload-artifact@v1
+        with:
+          name: rpm
+          path: _topdir/RPMS/x86_64

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -71,15 +71,14 @@ dependencies = [
 
 [[package]]
 name = "console"
-version = "0.9.2"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45e0f3986890b3acbc782009e2629dfe2baa430ac091519ce3be26164a2ae6c0"
+checksum = "6728a28023f207181b193262711102bfbaf47cc9d13bc71d0736607ef8efe88c"
 dependencies = [
  "clicolors-control",
  "encode_unicode",
  "lazy_static",
  "libc",
- "regex",
  "termios",
  "winapi",
 ]
@@ -113,9 +112,9 @@ dependencies = [
 
 [[package]]
 name = "insta"
-version = "0.13.1"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8df742abee84dbf27d20869c9adf77b0d8f7ea3eead13c2c9e3998d136a97058"
+checksum = "8de3f029212a3fe78a6090f1f2b993877ca245a9ded863f3fcbd6eae084fc1ed"
 dependencies = [
  "console",
  "difference",
@@ -151,7 +150,7 @@ checksum = "ae91b68aebc4ddb91978b11a1b02ddd8602a05ec19002801c5666000e05e0f83"
 
 [[package]]
 name = "lustre_collector"
-version = "0.2.11"
+version = "0.2.12"
 dependencies = [
  "clap",
  "combine",
@@ -178,27 +177,12 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.2"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "053a8c8bcc71fcce321828dc897a98ab9760bef03a4fc36693c231e5b3216cfe"
+checksum = "2bdc6c187c65bca4260c9011c9e3132efe4909da44726bad24cf7572ae338d7f"
 dependencies = [
  "proc-macro2",
 ]
-
-[[package]]
-name = "regex"
-version = "1.3.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "322cf97724bea3ee221b78fe25ac9c46114ebb51747ad5babd51a2fc6a8235a8"
-dependencies = [
- "regex-syntax",
-]
-
-[[package]]
-name = "regex-syntax"
-version = "0.6.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1132f845907680735a84409c3bebc64d1364a5683ffbce899550cd09d5eaefc1"
 
 [[package]]
 name = "ryu"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lustre_collector"
-version = "0.2.11"
+version = "0.2.12"
 license = "MIT"
 description = "Scrapes Lustre stats and aggregates into JSON or YAML"
 authors = ["IML Team <iml@whamcloud.com>"]
@@ -14,7 +14,7 @@ serde_yaml = "0.8"
 clap = "2.33"
 
 [dev-dependencies]
-insta = "0.13"
+insta = "0.15"
 
 [profile.release]
 lto = true

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ![rust](https://github.com/whamcloud/lustre-collector/workflows/rust/badge.svg?branch=master)
 
-![Crates.io](https://img.shields.io/crates/v/lustre_collector) ![docs.rs](https://docs.rs/lustre_collector/badge.svg?version=0.2.11)
+![Crates.io](https://img.shields.io/crates/v/lustre_collector) ![docs.rs](https://docs.rs/lustre_collector/badge.svg?version=0.2.12)
 
 This repo provides a parsed representation of common Lustre statistics.
 

--- a/lustre_collector.spec
+++ b/lustre_collector.spec
@@ -1,5 +1,5 @@
 Name: lustre_collector
-Version: 0.2.11
+Version: 0.2.12
 # Release Start
 Release: 1%{?dist}
 # Release End

--- a/src/base_parsers.rs
+++ b/src/base_parsers.rs
@@ -24,6 +24,14 @@ where
     token('.')
 }
 
+pub fn equals<I>() -> impl Parser<I, Output = char>
+where
+    I: Stream<Token = char>,
+    I::Error: ParseError<I::Token, I::Range, I::Position>,
+{
+    token('=')
+}
+
 pub fn word<I>() -> impl Parser<I, Output = String>
 where
     I: Stream<Token = char>,
@@ -73,6 +81,14 @@ where
     I::Error: ParseError<I::Token, I::Range, I::Position>,
 {
     take_until(period())
+}
+
+pub fn till_equals<I>() -> impl Parser<I, Output = String>
+where
+    I: Stream<Token = char>,
+    I::Error: ParseError<I::Token, I::Range, I::Position>,
+{
+    take_until(equals())
 }
 
 pub fn string_to<I>(x: &'static str, y: &'static str) -> impl Parser<I, Output = String>

--- a/src/main.rs
+++ b/src/main.rs
@@ -36,7 +36,7 @@ fn main() {
         .collect::<Vec<_>>();
 
     let matches = App::new("lustre_collector")
-        .version("0.1.0")
+        .version("0.2.12")
         .author("IML Team")
         .about("Grabs various Lustre statistics for display in JSON or YAML")
         .arg(

--- a/src/mds/client_count_parser.rs
+++ b/src/mds/client_count_parser.rs
@@ -1,0 +1,275 @@
+// Copyright (c) 2020 DDN. All rights reserved.
+// Use of this source code is governed by a MIT-style
+// license that can be found in the LICENSE file.
+
+use crate::{
+    base_parsers::{equals, period, till_equals},
+    types::{Param, Record, Target, TargetStat, TargetStats, TargetVariant},
+};
+use combine::{
+    attempt, choice,
+    error::ParseError,
+    look_ahead, many1, one_of,
+    parser::char::{alpha_num, newline, string},
+    sep_by1, sep_end_by,
+    stream::Stream,
+    token, Parser,
+};
+use std::{collections::BTreeMap, ops::Add};
+
+pub const EXPORTS: &str = "exports";
+
+pub fn params() -> Vec<String> {
+    vec![format!("mdt.*.{}.*.uuid", EXPORTS)]
+}
+
+pub fn parse<I>() -> impl Parser<I, Output = Vec<Record>>
+where
+    I: Stream<Token = char>,
+    I::Error: ParseError<I::Token, I::Range, I::Position>,
+{
+    many1(interface_clients())
+        .map(|xs: Vec<_>| {
+            xs.into_iter().fold(BTreeMap::new(), |mut acc, (k, v)| {
+                acc.entry(k).and_modify(|x| *x += v).or_insert(v);
+
+                acc
+            })
+        })
+        .map(|hm| {
+            hm.into_iter()
+                .map(|(k, value)| TargetStat {
+                    kind: TargetVariant::MDT,
+                    target: Target(k),
+                    param: Param("connected_clients".into()),
+                    value,
+                })
+                .map(TargetStats::ConnectedClients)
+                .map(Record::Target)
+                .collect()
+        })
+}
+
+fn interface_clients<I>() -> impl Parser<I, Output = (String, u64)>
+where
+    I: Stream<Token = char>,
+    I::Error: ParseError<I::Token, I::Range, I::Position>,
+{
+    (
+        attempt(mdt_interface()),
+        choice((
+            newline()
+                .with(sep_end_by(attempt(is_client()), newline()))
+                .map(|xs: Vec<_>| xs.into_iter().fold(0, Add::add)),
+            attempt(is_client()).skip(newline()),
+        )),
+    )
+}
+
+fn is_client<I>() -> impl Parser<I, Output = u64>
+where
+    I: Stream<Token = char>,
+    I::Error: ParseError<I::Token, I::Range, I::Position>,
+{
+    sep_by1::<Vec<_>, _, _, _>(many1::<String, _, _>(alpha_num()), token('-')).with(choice((
+        string("_UUID").map(|_| 0),
+        look_ahead(newline()).map(|_| 1),
+    )))
+}
+
+pub fn exports<I>() -> impl Parser<I, Output = ()>
+where
+    I: Stream<Token = char>,
+    I::Error: ParseError<I::Token, I::Range, I::Position>,
+{
+    (string("exports"), period(), till_equals(), equals()).map(drop)
+}
+
+fn mdt_interface<I>() -> impl Parser<I, Output = String>
+where
+    I: Stream<Token = char>,
+    I::Error: ParseError<I::Token, I::Range, I::Position>,
+{
+    (
+        string("mdt").skip(period()),
+        many1::<String, _, _>(alpha_num().or(one_of("_-".chars()))),
+        period().skip(exports()),
+    )
+        .map(|(_, x, _)| x)
+}
+
+#[cfg(test)]
+pub mod test {
+    use super::*;
+    use combine::parser::EasyParser;
+    use insta::assert_debug_snapshot;
+
+    #[test]
+    fn test_is_client() {
+        let result = is_client()
+            .easy_parse("a01e9c48-52f7-0c50-ff15-5aa13684bb5b\n")
+            .unwrap();
+
+        assert_debug_snapshot!(result)
+    }
+
+    #[test]
+    fn test_is_not_client() {
+        let result = is_client()
+            .parse("es01a-MDT0000-lwp-OST0000_UUID\n")
+            .unwrap();
+
+        assert_debug_snapshot!(result)
+    }
+
+    #[test]
+    fn test_export_param() {
+        let result = mdt_interface()
+            .easy_parse("mdt.es01a-MDT0000.exports.0@lo.uuid=")
+            .unwrap();
+
+        assert_debug_snapshot!(result)
+    }
+
+    #[test]
+    fn test_no_interface_clients() {
+        let result = interface_clients()
+            .easy_parse("mdt.fs-MDT0000.exports.0@lo.uuid=es01a-MDT0000-lwp-MDT0000_UUID\n")
+            .unwrap();
+
+        assert_debug_snapshot!(result)
+    }
+
+    #[test]
+    fn test_interface_clients() {
+        let result = interface_clients()
+            .easy_parse("mdt.fs-MDT0000.exports.0@lo.uuid=a01e9c48-52f7-0c50-ff15-5aa13684bb5b\n")
+            .unwrap();
+
+        assert_debug_snapshot!(result)
+    }
+
+    #[test]
+    fn test_multiple_interface_clients() {
+        let x = r#"mdt.fs-MDT0000.exports.0@lo.uuid=
+es01a-MDT0000-lwp-OST0002_UUID
+a01e9c48-52f7-0c50-ff15-5aa13684bb5a
+es01a-MDT0000-lwp-OST0001_UUID
+a01e9c48-52f7-0c50-ff15-5aa13684bb5b
+es01a-MDT0000-lwp-OST0000_UUID
+a01e9c48-52f7-0c50-ff15-5aa13684bb5c
+es01a-MDT0000-lwp-OST0000_UUID
+es01a-MDT0000-lwp-OST0000_UUID
+a01e9c48-52f7-0c50-ff15-5aa13684bb5c
+a01e9c48-52f7-0c50-ff15-5aa13684bb5c
+"#;
+
+        let result = interface_clients().easy_parse(x).unwrap();
+
+        assert_debug_snapshot!(result)
+    }
+
+    #[test]
+    fn test_client_count_parser_one_client() {
+        let x = r#"mdt.fs-MDT0000.exports.0@lo.uuid=es01a-MDT0000-lwp-MDT0000_UUID
+mdt.es01a-MDT0000.exports.172.60.0.2@o2ib.uuid=
+es01a-MDT0000-lwp-OST0002_UUID
+es01a-MDT0000-lwp-OST0001_UUID
+es01a-MDT0000-lwp-OST0000_UUID
+mdt.es01a-MDT0000.exports.172.60.0.4@o2ib.uuid=es01a-MDT0000-lwp-OST0003_UUID
+mdt.es01a-MDT0000.exports.172.60.14.106@o2ib.uuid=
+a01e9c48-52f7-0c50-ff15-5aa13684bb5b
+"#;
+
+        let result = parse().easy_parse(x).unwrap();
+
+        assert_debug_snapshot!(result)
+    }
+
+    #[test]
+    fn test_client_count_parser_zero_clients() {
+        let x = r#"mdt.fs-MDT0000.exports.0@lo.uuid=fs-MDT0000-lwp-MDT0000_UUID
+mdt.fs-MDT0000.exports.10.73.20.21@tcp.uuid=
+fs-MDT0000-lwp-OST000a_UUID
+fs-MDT0000-lwp-OST0004_UUID
+fs-MDT0000-lwp-OST0000_UUID
+fs-MDT0000-lwp-OST0006_UUID
+fs-MDT0000-lwp-OST0002_UUID
+fs-MDT0000-lwp-OST0008_UUID
+mdt.fs-MDT0000.exports.10.73.20.22@tcp.uuid=
+fs-MDT0000-lwp-OST0007_UUID
+fs-MDT0000-lwp-OST0003_UUID
+fs-MDT0000-lwp-OST0009_UUID
+fs-MDT0000-lwp-OST0001_UUID
+fs-MDT0000-lwp-OST000b_UUID
+fs-MDT0000-lwp-OST0005_UUID
+"#;
+
+        let result = parse().easy_parse(x).unwrap();
+
+        assert_debug_snapshot!(result)
+    }
+
+    #[test]
+    fn test_client_count_parser_two_clients() {
+        let x = r#"mdt.fs-MDT0000.exports.0@lo.uuid=fs-MDT0000-lwp-MDT0000_UUID
+mdt.fs-MDT0000.exports.10.0.2.15@tcp.uuid=
+613beb43-5df2-2ace-4209-be66b4b509df
+568acc64-085e-ada1-d493-6318930dfa74
+mdt.fs-MDT0000.exports.10.73.20.21@tcp.uuid=
+fs-MDT0000-lwp-OST000a_UUID
+fs-MDT0000-lwp-OST0004_UUID
+fs-MDT0000-lwp-OST0000_UUID
+fs-MDT0000-lwp-OST0006_UUID
+fs-MDT0000-lwp-OST0002_UUID
+fs-MDT0000-lwp-OST0008_UUID
+mdt.fs-MDT0000.exports.10.73.20.22@tcp.uuid=
+fs-MDT0000-lwp-OST0007_UUID
+fs-MDT0000-lwp-OST0003_UUID
+fs-MDT0000-lwp-OST0009_UUID
+fs-MDT0000-lwp-OST0001_UUID
+fs-MDT0000-lwp-OST000b_UUID
+fs-MDT0000-lwp-OST0005_UUID
+"#;
+
+        let result = parse().easy_parse(x).unwrap();
+
+        assert_debug_snapshot!(result)
+    }
+
+    #[test]
+    fn test_client_count_parser_multiple_fs() {
+        let x = r#"mdt.fs-MDT0000.exports.0@lo.uuid=fs-MDT0000-lwp-MDT0000_UUID
+mdt.fs-MDT0000.exports.10.0.2.15@tcp.uuid=
+613beb43-5df2-2ace-4209-be66b4b509df
+568acc64-085e-ada1-d493-6318930dfa74
+mdt.fs-MDT0000.exports.10.73.20.21@tcp.uuid=
+fs-MDT0000-lwp-OST000a_UUID
+fs-MDT0000-lwp-OST0004_UUID
+fs-MDT0000-lwp-OST0000_UUID
+fs-MDT0000-lwp-OST0006_UUID
+fs-MDT0000-lwp-OST0002_UUID
+fs-MDT0000-lwp-OST0008_UUID
+mdt.fs-MDT0000.exports.10.73.20.22@tcp.uuid=
+fs-MDT0000-lwp-OST0007_UUID
+fs-MDT0000-lwp-OST0003_UUID
+fs-MDT0000-lwp-OST0009_UUID
+fs-MDT0000-lwp-OST0001_UUID
+fs-MDT0000-lwp-OST000b_UUID
+fs-MDT0000-lwp-OST0005_UUID
+mdt.fs2-MDT0000.exports.0@lo.uuid=fs2-MDT0000-lwp-MDT0000_UUID
+mdt.fs2-MDT0000.exports.10.0.2.15@tcp.uuid=
+a7b7c685-18c1-eecc-eae2-5880f431cae3
+6f2afad1-ff3a-cdd0-721f-dcc123cae427
+mdt.fs2-MDT0000.exports.10.73.20.12@tcp.uuid=fs2-MDT0000-lwp-OST0002_UUID
+mdt.fs2-MDT0000.exports.10.73.20.21@tcp.uuid=
+fs2-MDT0000-lwp-OST0003_UUID
+fs2-MDT0000-lwp-OST0000_UUID
+mdt.fs2-MDT0000.exports.10.73.20.22@tcp.uuid=fs2-MDT0000-lwp-OST0001_UUID
+"#;
+
+        let result = parse().easy_parse(x).unwrap();
+
+        assert_debug_snapshot!(result)
+    }
+}

--- a/src/mds/mds_parser.rs
+++ b/src/mds/mds_parser.rs
@@ -166,7 +166,7 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
-    use combine::many;
+    use combine::{many, parser::EasyParser};
     use insta::assert_debug_snapshot;
 
     #[test]
@@ -200,7 +200,7 @@ osd-ldiskfs.fs-MDT0002.kbytesfree=2893076
 osd-ldiskfs.fs-MDT0002.kbytestotal=2913312
 "#;
 
-        let result: (Vec<_>, _) = many(parse()).parse(x).unwrap();
+        let result: (Vec<_>, _) = many(parse()).easy_parse(x).unwrap();
 
         assert_debug_snapshot!(result)
     }

--- a/src/mds/mod.rs
+++ b/src/mds/mod.rs
@@ -2,4 +2,5 @@
 // Use of this source code is governed by a MIT-style
 // license that can be found in the LICENSE file.
 
+pub mod client_count_parser;
 pub mod mds_parser;

--- a/src/mds/snapshots/lustre_collector__mds__client_count_parser__test__client_count_parser_multiple_fs.snap
+++ b/src/mds/snapshots/lustre_collector__mds__client_count_parser__test__client_count_parser_multiple_fs.snap
@@ -1,0 +1,37 @@
+---
+source: src/mds/client_count_parser.rs
+expression: result
+---
+(
+    [
+        Target(
+            ConnectedClients(
+                TargetStat {
+                    kind: MDT,
+                    param: Param(
+                        "connected_clients",
+                    ),
+                    target: Target(
+                        "fs-MDT0000",
+                    ),
+                    value: 2,
+                },
+            ),
+        ),
+        Target(
+            ConnectedClients(
+                TargetStat {
+                    kind: MDT,
+                    param: Param(
+                        "connected_clients",
+                    ),
+                    target: Target(
+                        "fs2-MDT0000",
+                    ),
+                    value: 2,
+                },
+            ),
+        ),
+    ],
+    "",
+)

--- a/src/mds/snapshots/lustre_collector__mds__client_count_parser__test__client_count_parser_one_client.snap
+++ b/src/mds/snapshots/lustre_collector__mds__client_count_parser__test__client_count_parser_one_client.snap
@@ -1,0 +1,37 @@
+---
+source: src/mds/client_count_parser.rs
+expression: result
+---
+(
+    [
+        Target(
+            ConnectedClients(
+                TargetStat {
+                    kind: MDT,
+                    param: Param(
+                        "connected_clients",
+                    ),
+                    target: Target(
+                        "es01a-MDT0000",
+                    ),
+                    value: 1,
+                },
+            ),
+        ),
+        Target(
+            ConnectedClients(
+                TargetStat {
+                    kind: MDT,
+                    param: Param(
+                        "connected_clients",
+                    ),
+                    target: Target(
+                        "fs-MDT0000",
+                    ),
+                    value: 0,
+                },
+            ),
+        ),
+    ],
+    "",
+)

--- a/src/mds/snapshots/lustre_collector__mds__client_count_parser__test__client_count_parser_two_clients.snap
+++ b/src/mds/snapshots/lustre_collector__mds__client_count_parser__test__client_count_parser_two_clients.snap
@@ -1,0 +1,23 @@
+---
+source: src/mds/client_count_parser.rs
+expression: result
+---
+(
+    [
+        Target(
+            ConnectedClients(
+                TargetStat {
+                    kind: MDT,
+                    param: Param(
+                        "connected_clients",
+                    ),
+                    target: Target(
+                        "fs-MDT0000",
+                    ),
+                    value: 2,
+                },
+            ),
+        ),
+    ],
+    "",
+)

--- a/src/mds/snapshots/lustre_collector__mds__client_count_parser__test__client_count_parser_zero_clients.snap
+++ b/src/mds/snapshots/lustre_collector__mds__client_count_parser__test__client_count_parser_zero_clients.snap
@@ -1,0 +1,23 @@
+---
+source: src/mds/client_count_parser.rs
+expression: result
+---
+(
+    [
+        Target(
+            ConnectedClients(
+                TargetStat {
+                    kind: MDT,
+                    param: Param(
+                        "connected_clients",
+                    ),
+                    target: Target(
+                        "fs-MDT0000",
+                    ),
+                    value: 0,
+                },
+            ),
+        ),
+    ],
+    "",
+)

--- a/src/mds/snapshots/lustre_collector__mds__client_count_parser__test__export_param.snap
+++ b/src/mds/snapshots/lustre_collector__mds__client_count_parser__test__export_param.snap
@@ -1,0 +1,8 @@
+---
+source: src/mds/client_count_parser.rs
+expression: result
+---
+(
+    "es01a-MDT0000",
+    "",
+)

--- a/src/mds/snapshots/lustre_collector__mds__client_count_parser__test__interface_clients.snap
+++ b/src/mds/snapshots/lustre_collector__mds__client_count_parser__test__interface_clients.snap
@@ -1,0 +1,11 @@
+---
+source: src/mds/client_count_parser.rs
+expression: result
+---
+(
+    (
+        "fs-MDT0000",
+        1,
+    ),
+    "",
+)

--- a/src/mds/snapshots/lustre_collector__mds__client_count_parser__test__is_client.snap
+++ b/src/mds/snapshots/lustre_collector__mds__client_count_parser__test__is_client.snap
@@ -1,0 +1,8 @@
+---
+source: src/mds/client_count_parser.rs
+expression: result
+---
+(
+    1,
+    "\n",
+)

--- a/src/mds/snapshots/lustre_collector__mds__client_count_parser__test__is_not_client.snap
+++ b/src/mds/snapshots/lustre_collector__mds__client_count_parser__test__is_not_client.snap
@@ -1,0 +1,8 @@
+---
+source: src/mds/client_count_parser.rs
+expression: result
+---
+(
+    0,
+    "\n",
+)

--- a/src/mds/snapshots/lustre_collector__mds__client_count_parser__test__multiple_interface_clients.snap
+++ b/src/mds/snapshots/lustre_collector__mds__client_count_parser__test__multiple_interface_clients.snap
@@ -1,0 +1,11 @@
+---
+source: src/mds/client_count_parser.rs
+expression: result
+---
+(
+    (
+        "fs-MDT0000",
+        5,
+    ),
+    "",
+)

--- a/src/mds/snapshots/lustre_collector__mds__client_count_parser__test__no_interface_clients.snap
+++ b/src/mds/snapshots/lustre_collector__mds__client_count_parser__test__no_interface_clients.snap
@@ -1,0 +1,11 @@
+---
+source: src/mds/client_count_parser.rs
+expression: result
+---
+(
+    (
+        "fs-MDT0000",
+        0,
+    ),
+    "",
+)

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -2,11 +2,18 @@
 // Use of this source code is governed by a MIT-style
 // license that can be found in the LICENSE file.
 
-use crate::{mds::mds_parser, mgs::mgs_parser, oss::oss_parser, top_level_parser, types::Record};
+use crate::{
+    mds::{client_count_parser, mds_parser},
+    mgs::mgs_parser,
+    oss::oss_parser,
+    top_level_parser,
+    types::Record,
+};
 use combine::{choice, error::ParseError, many, Parser, Stream};
 
 pub fn params() -> Vec<String> {
     let mut a = top_level_parser::top_level_params();
+    a.extend(client_count_parser::params());
     a.extend(mgs_parser::params());
     a.extend(oss_parser::params());
     a.extend(mds_parser::params());
@@ -19,20 +26,110 @@ where
     I::Error: ParseError<I::Token, I::Range, I::Position>,
 {
     many(choice((
-        top_level_parser::parse(),
-        mgs_parser::parse(),
-        mds_parser::parse(),
-        oss_parser::parse(),
+        top_level_parser::parse().map(|x| vec![x]),
+        client_count_parser::parse(),
+        mgs_parser::parse().map(|x| vec![x]),
+        mds_parser::parse().map(|x| vec![x]),
+        oss_parser::parse().map(|x| vec![x]),
     )))
+    .map(|xs: Vec<_>| xs.into_iter().flatten().collect())
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use combine::parser::EasyParser;
     use insta::assert_debug_snapshot;
 
     #[test]
     fn test_params() {
         assert_debug_snapshot!(params());
+    }
+
+    #[test]
+    fn test_mdt_output() {
+        let x = r#"memused=343719411
+memused_max=344830779
+lnet_memused=140274209
+health_check=healthy
+mdt.fs-MDT0000.exports.0@lo.uuid=fs-MDT0000-lwp-MDT0000_UUID
+mdt.fs-MDT0000.exports.10.0.2.15@tcp.uuid=
+613beb43-5df2-2ace-4209-be66b4b509df
+568acc64-085e-ada1-d493-6318930dfa74
+mdt.fs-MDT0000.exports.10.73.20.21@tcp.uuid=
+fs-MDT0000-lwp-OST000a_UUID
+fs-MDT0000-lwp-OST0004_UUID
+fs-MDT0000-lwp-OST0000_UUID
+fs-MDT0000-lwp-OST0006_UUID
+fs-MDT0000-lwp-OST0002_UUID
+fs-MDT0000-lwp-OST0008_UUID
+mdt.fs-MDT0000.exports.10.73.20.22@tcp.uuid=
+fs-MDT0000-lwp-OST0007_UUID
+fs-MDT0000-lwp-OST0003_UUID
+fs-MDT0000-lwp-OST0009_UUID
+fs-MDT0000-lwp-OST0001_UUID
+fs-MDT0000-lwp-OST000b_UUID
+fs-MDT0000-lwp-OST0005_UUID
+mdt.fs2-MDT0000.exports.0@lo.uuid=fs2-MDT0000-lwp-MDT0000_UUID
+mdt.fs2-MDT0000.exports.10.0.2.15@tcp.uuid=
+a7b7c685-18c1-eecc-eae2-5880f431cae3
+6f2afad1-ff3a-cdd0-721f-dcc123cae427
+mdt.fs2-MDT0000.exports.10.73.20.12@tcp.uuid=fs2-MDT0000-lwp-OST0002_UUID
+mdt.fs2-MDT0000.exports.10.73.20.21@tcp.uuid=
+fs2-MDT0000-lwp-OST0003_UUID
+fs2-MDT0000-lwp-OST0000_UUID
+mdt.fs2-MDT0000.exports.10.73.20.22@tcp.uuid=fs2-MDT0000-lwp-OST0001_UUID
+ldlm.namespaces.mdt-fs-MDT0000_UUID.contended_locks=32
+ldlm.namespaces.mdt-fs2-MDT0000_UUID.contended_locks=32
+ldlm.namespaces.mdt-fs-MDT0000_UUID.contention_seconds=2
+ldlm.namespaces.mdt-fs2-MDT0000_UUID.contention_seconds=2
+ldlm.namespaces.mdt-fs-MDT0000_UUID.ctime_age_limit=10
+ldlm.namespaces.mdt-fs2-MDT0000_UUID.ctime_age_limit=10
+ldlm.namespaces.mdt-fs-MDT0000_UUID.early_lock_cancel=0
+ldlm.namespaces.mdt-fs2-MDT0000_UUID.early_lock_cancel=0
+ldlm.namespaces.mdt-fs-MDT0000_UUID.lock_count=0
+ldlm.namespaces.mdt-fs2-MDT0000_UUID.lock_count=0
+ldlm.namespaces.mdt-fs-MDT0000_UUID.lock_timeouts=0
+ldlm.namespaces.mdt-fs2-MDT0000_UUID.lock_timeouts=0
+ldlm.namespaces.mdt-fs-MDT0000_UUID.lock_unused_count=0
+ldlm.namespaces.mdt-fs2-MDT0000_UUID.lock_unused_count=0
+ldlm.namespaces.mdt-fs-MDT0000_UUID.lru_max_age=3900000
+ldlm.namespaces.mdt-fs2-MDT0000_UUID.lru_max_age=3900000
+ldlm.namespaces.mdt-fs-MDT0000_UUID.lru_size=800
+ldlm.namespaces.mdt-fs2-MDT0000_UUID.lru_size=800
+ldlm.namespaces.mdt-fs-MDT0000_UUID.max_nolock_bytes=0
+ldlm.namespaces.mdt-fs2-MDT0000_UUID.max_nolock_bytes=0
+ldlm.namespaces.mdt-fs-MDT0000_UUID.max_parallel_ast=1024
+ldlm.namespaces.mdt-fs2-MDT0000_UUID.max_parallel_ast=1024
+ldlm.namespaces.mdt-fs-MDT0000_UUID.resource_count=0
+ldlm.namespaces.mdt-fs2-MDT0000_UUID.resource_count=0
+mdt.fs-MDT0000.md_stats=
+snapshot_time             1583789082.568118366 secs.nsecs
+getattr                   4 samples [reqs]
+statfs                    2 samples [reqs]
+mdt.fs2-MDT0000.md_stats=
+snapshot_time             1583789082.568222478 secs.nsecs
+getattr                   2 samples [reqs]
+statfs                    2 samples [reqs]
+mdt.fs-MDT0000.num_exports=15
+mdt.fs2-MDT0000.num_exports=7
+osd-ldiskfs.fs-MDT0000.filesfree=2621151
+osd-ldiskfs.fs2-MDT0000.filesfree=2621167
+osd-ldiskfs.fs-MDT0000.filestotal=2621440
+osd-ldiskfs.fs2-MDT0000.filestotal=2621440
+osd-ldiskfs.fs-MDT0000.kbytesavail=1531876
+osd-ldiskfs.fs2-MDT0000.kbytesavail=1532068
+osd-ldiskfs.fs-MDT0000.kbytesfree=1793268
+osd-ldiskfs.fs2-MDT0000.kbytesfree=1793460
+osd-ldiskfs.fs-MDT0000.kbytestotal=1819968
+osd-ldiskfs.fs2-MDT0000.kbytestotal=1819968
+"#;
+
+        let result = parse()
+            .easy_parse(x)
+            .map_err(|err| err.map_position(|p| p.translate_position(x)))
+            .unwrap();
+
+        assert_debug_snapshot!(result);
     }
 }

--- a/src/snapshots/lustre_collector__parser__tests__mdt_output.snap
+++ b/src/snapshots/lustre_collector__parser__tests__mdt_output.snap
@@ -1,0 +1,647 @@
+---
+source: src/parser.rs
+expression: result
+---
+(
+    [
+        Host(
+            Memused(
+                HostStat {
+                    param: Param(
+                        "memused",
+                    ),
+                    value: 343719411,
+                },
+            ),
+        ),
+        Host(
+            MemusedMax(
+                HostStat {
+                    param: Param(
+                        "memused_max",
+                    ),
+                    value: 344830779,
+                },
+            ),
+        ),
+        Host(
+            LNetMemUsed(
+                HostStat {
+                    param: Param(
+                        "lnet_memused",
+                    ),
+                    value: 140274209,
+                },
+            ),
+        ),
+        Host(
+            HealthCheck(
+                HostStat {
+                    param: Param(
+                        "health_check",
+                    ),
+                    value: "healthy",
+                },
+            ),
+        ),
+        Target(
+            ConnectedClients(
+                TargetStat {
+                    kind: MDT,
+                    param: Param(
+                        "connected_clients",
+                    ),
+                    target: Target(
+                        "fs-MDT0000",
+                    ),
+                    value: 2,
+                },
+            ),
+        ),
+        Target(
+            ConnectedClients(
+                TargetStat {
+                    kind: MDT,
+                    param: Param(
+                        "connected_clients",
+                    ),
+                    target: Target(
+                        "fs2-MDT0000",
+                    ),
+                    value: 2,
+                },
+            ),
+        ),
+        Target(
+            ContendedLocks(
+                TargetStat {
+                    kind: MDT,
+                    param: Param(
+                        "contended_locks",
+                    ),
+                    target: Target(
+                        "fs-MDT0000",
+                    ),
+                    value: 32,
+                },
+            ),
+        ),
+        Target(
+            ContendedLocks(
+                TargetStat {
+                    kind: MDT,
+                    param: Param(
+                        "contended_locks",
+                    ),
+                    target: Target(
+                        "fs2-MDT0000",
+                    ),
+                    value: 32,
+                },
+            ),
+        ),
+        Target(
+            ContentionSeconds(
+                TargetStat {
+                    kind: MDT,
+                    param: Param(
+                        "contention_seconds",
+                    ),
+                    target: Target(
+                        "fs-MDT0000",
+                    ),
+                    value: 2,
+                },
+            ),
+        ),
+        Target(
+            ContentionSeconds(
+                TargetStat {
+                    kind: MDT,
+                    param: Param(
+                        "contention_seconds",
+                    ),
+                    target: Target(
+                        "fs2-MDT0000",
+                    ),
+                    value: 2,
+                },
+            ),
+        ),
+        Target(
+            CtimeAgeLimit(
+                TargetStat {
+                    kind: MDT,
+                    param: Param(
+                        "ctime_age_limit",
+                    ),
+                    target: Target(
+                        "fs-MDT0000",
+                    ),
+                    value: 10,
+                },
+            ),
+        ),
+        Target(
+            CtimeAgeLimit(
+                TargetStat {
+                    kind: MDT,
+                    param: Param(
+                        "ctime_age_limit",
+                    ),
+                    target: Target(
+                        "fs2-MDT0000",
+                    ),
+                    value: 10,
+                },
+            ),
+        ),
+        Target(
+            EarlyLockCancel(
+                TargetStat {
+                    kind: MDT,
+                    param: Param(
+                        "early_lock_cancel",
+                    ),
+                    target: Target(
+                        "fs-MDT0000",
+                    ),
+                    value: 0,
+                },
+            ),
+        ),
+        Target(
+            EarlyLockCancel(
+                TargetStat {
+                    kind: MDT,
+                    param: Param(
+                        "early_lock_cancel",
+                    ),
+                    target: Target(
+                        "fs2-MDT0000",
+                    ),
+                    value: 0,
+                },
+            ),
+        ),
+        Target(
+            LockCount(
+                TargetStat {
+                    kind: MDT,
+                    param: Param(
+                        "lock_count",
+                    ),
+                    target: Target(
+                        "fs-MDT0000",
+                    ),
+                    value: 0,
+                },
+            ),
+        ),
+        Target(
+            LockCount(
+                TargetStat {
+                    kind: MDT,
+                    param: Param(
+                        "lock_count",
+                    ),
+                    target: Target(
+                        "fs2-MDT0000",
+                    ),
+                    value: 0,
+                },
+            ),
+        ),
+        Target(
+            LockTimeouts(
+                TargetStat {
+                    kind: MDT,
+                    param: Param(
+                        "lock_timeouts",
+                    ),
+                    target: Target(
+                        "fs-MDT0000",
+                    ),
+                    value: 0,
+                },
+            ),
+        ),
+        Target(
+            LockTimeouts(
+                TargetStat {
+                    kind: MDT,
+                    param: Param(
+                        "lock_timeouts",
+                    ),
+                    target: Target(
+                        "fs2-MDT0000",
+                    ),
+                    value: 0,
+                },
+            ),
+        ),
+        Target(
+            LockUnusedCount(
+                TargetStat {
+                    kind: MDT,
+                    param: Param(
+                        "lock_unused_count",
+                    ),
+                    target: Target(
+                        "fs-MDT0000",
+                    ),
+                    value: 0,
+                },
+            ),
+        ),
+        Target(
+            LockUnusedCount(
+                TargetStat {
+                    kind: MDT,
+                    param: Param(
+                        "lock_unused_count",
+                    ),
+                    target: Target(
+                        "fs2-MDT0000",
+                    ),
+                    value: 0,
+                },
+            ),
+        ),
+        Target(
+            LruMaxAge(
+                TargetStat {
+                    kind: MDT,
+                    param: Param(
+                        "lru_max_age",
+                    ),
+                    target: Target(
+                        "fs-MDT0000",
+                    ),
+                    value: 3900000,
+                },
+            ),
+        ),
+        Target(
+            LruMaxAge(
+                TargetStat {
+                    kind: MDT,
+                    param: Param(
+                        "lru_max_age",
+                    ),
+                    target: Target(
+                        "fs2-MDT0000",
+                    ),
+                    value: 3900000,
+                },
+            ),
+        ),
+        Target(
+            LruSize(
+                TargetStat {
+                    kind: MDT,
+                    param: Param(
+                        "lru_size",
+                    ),
+                    target: Target(
+                        "fs-MDT0000",
+                    ),
+                    value: 800,
+                },
+            ),
+        ),
+        Target(
+            LruSize(
+                TargetStat {
+                    kind: MDT,
+                    param: Param(
+                        "lru_size",
+                    ),
+                    target: Target(
+                        "fs2-MDT0000",
+                    ),
+                    value: 800,
+                },
+            ),
+        ),
+        Target(
+            MaxNolockBytes(
+                TargetStat {
+                    kind: MDT,
+                    param: Param(
+                        "max_nolock_bytes",
+                    ),
+                    target: Target(
+                        "fs-MDT0000",
+                    ),
+                    value: 0,
+                },
+            ),
+        ),
+        Target(
+            MaxNolockBytes(
+                TargetStat {
+                    kind: MDT,
+                    param: Param(
+                        "max_nolock_bytes",
+                    ),
+                    target: Target(
+                        "fs2-MDT0000",
+                    ),
+                    value: 0,
+                },
+            ),
+        ),
+        Target(
+            MaxParallelAst(
+                TargetStat {
+                    kind: MDT,
+                    param: Param(
+                        "max_parallel_ast",
+                    ),
+                    target: Target(
+                        "fs-MDT0000",
+                    ),
+                    value: 1024,
+                },
+            ),
+        ),
+        Target(
+            MaxParallelAst(
+                TargetStat {
+                    kind: MDT,
+                    param: Param(
+                        "max_parallel_ast",
+                    ),
+                    target: Target(
+                        "fs2-MDT0000",
+                    ),
+                    value: 1024,
+                },
+            ),
+        ),
+        Target(
+            ResourceCount(
+                TargetStat {
+                    kind: MDT,
+                    param: Param(
+                        "resource_count",
+                    ),
+                    target: Target(
+                        "fs-MDT0000",
+                    ),
+                    value: 0,
+                },
+            ),
+        ),
+        Target(
+            ResourceCount(
+                TargetStat {
+                    kind: MDT,
+                    param: Param(
+                        "resource_count",
+                    ),
+                    target: Target(
+                        "fs2-MDT0000",
+                    ),
+                    value: 0,
+                },
+            ),
+        ),
+        Target(
+            Stats(
+                TargetStat {
+                    kind: MDT,
+                    param: Param(
+                        "md_stats",
+                    ),
+                    target: Target(
+                        "fs-MDT0000",
+                    ),
+                    value: [
+                        Stat {
+                            name: "getattr",
+                            units: "reqs",
+                            samples: 4,
+                            min: None,
+                            max: None,
+                            sum: None,
+                            sumsquare: None,
+                        },
+                        Stat {
+                            name: "statfs",
+                            units: "reqs",
+                            samples: 2,
+                            min: None,
+                            max: None,
+                            sum: None,
+                            sumsquare: None,
+                        },
+                    ],
+                },
+            ),
+        ),
+        Target(
+            Stats(
+                TargetStat {
+                    kind: MDT,
+                    param: Param(
+                        "md_stats",
+                    ),
+                    target: Target(
+                        "fs2-MDT0000",
+                    ),
+                    value: [
+                        Stat {
+                            name: "getattr",
+                            units: "reqs",
+                            samples: 2,
+                            min: None,
+                            max: None,
+                            sum: None,
+                            sumsquare: None,
+                        },
+                        Stat {
+                            name: "statfs",
+                            units: "reqs",
+                            samples: 2,
+                            min: None,
+                            max: None,
+                            sum: None,
+                            sumsquare: None,
+                        },
+                    ],
+                },
+            ),
+        ),
+        Target(
+            NumExports(
+                TargetStat {
+                    kind: MDT,
+                    param: Param(
+                        "num_exports",
+                    ),
+                    target: Target(
+                        "fs-MDT0000",
+                    ),
+                    value: 15,
+                },
+            ),
+        ),
+        Target(
+            NumExports(
+                TargetStat {
+                    kind: MDT,
+                    param: Param(
+                        "num_exports",
+                    ),
+                    target: Target(
+                        "fs2-MDT0000",
+                    ),
+                    value: 7,
+                },
+            ),
+        ),
+        Target(
+            FilesFree(
+                TargetStat {
+                    kind: MDT,
+                    param: Param(
+                        "filesfree",
+                    ),
+                    target: Target(
+                        "fs-MDT0000",
+                    ),
+                    value: 2621151,
+                },
+            ),
+        ),
+        Target(
+            FilesFree(
+                TargetStat {
+                    kind: MDT,
+                    param: Param(
+                        "filesfree",
+                    ),
+                    target: Target(
+                        "fs2-MDT0000",
+                    ),
+                    value: 2621167,
+                },
+            ),
+        ),
+        Target(
+            FilesTotal(
+                TargetStat {
+                    kind: MDT,
+                    param: Param(
+                        "filestotal",
+                    ),
+                    target: Target(
+                        "fs-MDT0000",
+                    ),
+                    value: 2621440,
+                },
+            ),
+        ),
+        Target(
+            FilesTotal(
+                TargetStat {
+                    kind: MDT,
+                    param: Param(
+                        "filestotal",
+                    ),
+                    target: Target(
+                        "fs2-MDT0000",
+                    ),
+                    value: 2621440,
+                },
+            ),
+        ),
+        Target(
+            BytesAvail(
+                TargetStat {
+                    kind: MDT,
+                    param: Param(
+                        "kbytesavail",
+                    ),
+                    target: Target(
+                        "fs-MDT0000",
+                    ),
+                    value: 1568641024,
+                },
+            ),
+        ),
+        Target(
+            BytesAvail(
+                TargetStat {
+                    kind: MDT,
+                    param: Param(
+                        "kbytesavail",
+                    ),
+                    target: Target(
+                        "fs2-MDT0000",
+                    ),
+                    value: 1568837632,
+                },
+            ),
+        ),
+        Target(
+            BytesFree(
+                TargetStat {
+                    kind: MDT,
+                    param: Param(
+                        "kbytesfree",
+                    ),
+                    target: Target(
+                        "fs-MDT0000",
+                    ),
+                    value: 1836306432,
+                },
+            ),
+        ),
+        Target(
+            BytesFree(
+                TargetStat {
+                    kind: MDT,
+                    param: Param(
+                        "kbytesfree",
+                    ),
+                    target: Target(
+                        "fs2-MDT0000",
+                    ),
+                    value: 1836503040,
+                },
+            ),
+        ),
+        Target(
+            BytesTotal(
+                TargetStat {
+                    kind: MDT,
+                    param: Param(
+                        "kbytestotal",
+                    ),
+                    target: Target(
+                        "fs-MDT0000",
+                    ),
+                    value: 1863647232,
+                },
+            ),
+        ),
+        Target(
+            BytesTotal(
+                TargetStat {
+                    kind: MDT,
+                    param: Param(
+                        "kbytestotal",
+                    ),
+                    target: Target(
+                        "fs2-MDT0000",
+                    ),
+                    value: 1863647232,
+                },
+            ),
+        ),
+    ],
+    "",
+)

--- a/src/snapshots/lustre_collector__parser__tests__params.snap
+++ b/src/snapshots/lustre_collector__parser__tests__params.snap
@@ -7,6 +7,7 @@ expression: params()
     "memused_max",
     "lnet_memused",
     "health_check",
+    "mdt.*.exports.*.uuid",
     "mgs.*.mgs.stats",
     "mgs.*.mgs.threads_max",
     "mgs.*.mgs.threads_min",

--- a/src/types.rs
+++ b/src/types.rs
@@ -320,6 +320,7 @@ pub enum TargetStats {
     TotPending(TargetStat<u64>),
     ContendedLocks(TargetStat<u64>),
     ContentionSeconds(TargetStat<u64>),
+    ConnectedClients(TargetStat<u64>),
     CtimeAgeLimit(TargetStat<u64>),
     EarlyLockCancel(TargetStat<u64>),
     LockCount(TargetStat<u64>),


### PR DESCRIPTION
Add a new parser that calculates the currently connected clients on a per-fs level.

Signed-off-by: Joe Grund <jgrund@whamcloud.io>