### PR TITLE
EX-1552 - Implement parser to get MGS filesystems

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,7 +6,7 @@ mod base_parsers;
 pub mod error;
 mod lnetctl_parser;
 mod mds;
-mod mgs;
+pub mod mgs;
 mod node_stats_parsers;
 mod oss;
 pub mod parser;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -39,3 +39,21 @@ pub fn parse_lctl_output(lctl_output: &[u8]) -> Result<Vec<Record>, LustreCollec
 
     Ok(lctl_record)
 }
+
+pub fn parse_mgs_fs_output(mgs_fs_output: &[u8]) -> Result<Vec<Record>, LustreCollectorError> {
+    let mgs_fs = str::from_utf8(mgs_fs_output)?;
+
+    let (mgs_fs_record, state) = mgs::mgs_fs_parser::parse()
+        .easy_parse(mgs_fs)
+        .map_err(|err| err.map_position(|p| p.translate_position(mgs_fs)))?;
+
+    if state != "" {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            format!("Content left in input buffer: {}", state),
+        )
+        .into());
+    }
+
+    Ok(mgs_fs_record)
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,13 +22,7 @@ pub use node_stats_parsers::{parse_cpustats_output, parse_meminfo_output};
 use std::{io, str};
 pub use types::*;
 
-pub fn parse_lctl_output(lctl_output: &[u8]) -> Result<Vec<Record>, LustreCollectorError> {
-    let lctl_stats = str::from_utf8(lctl_output)?;
-
-    let (lctl_record, state) = parser::parse()
-        .easy_parse(lctl_stats)
-        .map_err(|err| err.map_position(|p| p.translate_position(lctl_stats)))?;
-
+fn check_output(records: Vec<Record>, state: &str) -> Result<Vec<Record>, LustreCollectorError> {
     if state != "" {
         return Err(io::Error::new(
             io::ErrorKind::InvalidInput,
@@ -37,7 +31,17 @@ pub fn parse_lctl_output(lctl_output: &[u8]) -> Result<Vec<Record>, LustreCollec
         .into());
     }
 
-    Ok(lctl_record)
+    Ok(records)
+}
+
+pub fn parse_lctl_output(lctl_output: &[u8]) -> Result<Vec<Record>, LustreCollectorError> {
+    let lctl_stats = str::from_utf8(lctl_output)?;
+
+    let (lctl_record, state) = parser::parse()
+        .easy_parse(lctl_stats)
+        .map_err(|err| err.map_position(|p| p.translate_position(lctl_stats)))?;
+
+    check_output(lctl_record, state)
 }
 
 pub fn parse_mgs_fs_output(mgs_fs_output: &[u8]) -> Result<Vec<Record>, LustreCollectorError> {
@@ -47,13 +51,5 @@ pub fn parse_mgs_fs_output(mgs_fs_output: &[u8]) -> Result<Vec<Record>, LustreCo
         .easy_parse(mgs_fs)
         .map_err(|err| err.map_position(|p| p.translate_position(mgs_fs)))?;
 
-    if state != "" {
-        return Err(io::Error::new(
-            io::ErrorKind::InvalidInput,
-            format!("Content left in input buffer: {}", state),
-        )
-        .into());
-    }
-
-    Ok(mgs_fs_record)
+    check_output(mgs_fs_record, state)
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,7 +4,8 @@
 
 use clap::{arg_enum, value_t, App, Arg};
 use lustre_collector::{
-    error::LustreCollectorError, mgs::mgs_fs_parser, parse_lctl_output, parse_lnetctl_output, parser, types::Record,
+    error::LustreCollectorError, mgs::mgs_fs_parser, parse_lctl_output, parse_lnetctl_output,
+    parser, types::Record,
 };
 use std::{
     error::Error as _,

--- a/src/main.rs
+++ b/src/main.rs
@@ -29,6 +29,16 @@ fn get_lctl_output() -> Result<Vec<u8>, LustreCollectorError> {
     Ok(r.stdout)
 }
 
+fn get_lctl_name_only_output() -> Result<Vec<u8>, LustreCollectorError> {
+    let r = Command::new("lctl")
+        .arg("get_param")
+        .arg("-N")
+        .args(parser::name_only_params())
+        .output()?;
+
+    Ok(r.stdout)
+}
+
 fn main() {
     let variants = &Format::variants()
         .iter()
@@ -54,7 +64,12 @@ fn main() {
 
     let handle = thread::spawn(move || -> Result<Vec<Record>, LustreCollectorError> {
         let lctl_output = get_lctl_output()?;
-        let lctl_record = parse_lctl_output(&lctl_output)?;
+        let lctl_name_only_output = get_lctl_name_only_output()?;
+
+        let mut lctl_record = parse_lctl_output(&lctl_output)?;
+        let lctl_name_only_record = parse_lctl_output(&lctl_name_only_output)?;
+
+        lctl_record.extend(lctl_name_only_record);
 
         Ok(lctl_record)
     });

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,7 +5,7 @@
 use clap::{arg_enum, value_t, App, Arg};
 use lustre_collector::{
     error::LustreCollectorError, mgs::mgs_fs_parser, parse_lctl_output, parse_lnetctl_output,
-    parser, types::Record,
+    parse_mgs_fs_output, parser, types::Record,
 };
 use std::{
     error::Error as _,
@@ -72,7 +72,7 @@ fn main() {
 
     let mgs_fs_handle = thread::spawn(move || -> Result<Vec<Record>, LustreCollectorError> {
         let lctl_output = get_lctl_mgs_fs_output()?;
-        let lctl_record = parse_lctl_output(&lctl_output)?;
+        let lctl_record = parse_mgs_fs_output(&lctl_output)?;
 
         Ok(lctl_record)
     });

--- a/src/mgs/mgs_fs_parser.rs
+++ b/src/mgs/mgs_fs_parser.rs
@@ -91,7 +91,7 @@ where
                     .map(|(target, fs_name)| {
                         TargetStats::FsNames(TargetStat {
                             kind: TargetVariant::MGT,
-                            target: target,
+                            target,
                             param: param.clone(),
                             value: fs_name,
                         })
@@ -100,7 +100,7 @@ where
                     .collect::<Vec<_>>()
             }
         })
-        .message("while parsing mgs params")
+        .message("while parsing mgs fs params")
 }
 
 #[cfg(test)]

--- a/src/mgs/mgs_fs_parser.rs
+++ b/src/mgs/mgs_fs_parser.rs
@@ -75,14 +75,11 @@ where
                 let mgs_map: HashMap<Target, Vec<FsName>> =
                     xs.into_iter()
                         .fold(HashMap::new(), |mut acc, (target, fs_name)| {
-                            if let Some(fs_names) = acc.get(&target) {
-                                let names: Vec<FsName> =
-                                    [&fs_names[..], &vec![fs_name][..]].concat();
-                                acc.insert(target, names);
-                            } else {
-                                acc.insert(target, vec![fs_name]);
-                            }
-
+                            let fs_names = acc.entry(target.clone()).or_insert(vec![]);
+                            let names: Vec<FsName> =
+                                [&fs_names[..], &vec![fs_name][..]].concat();
+                            acc.insert(target, names);
+                            
                             acc
                         });
 

--- a/src/mgs/mgs_fs_parser.rs
+++ b/src/mgs/mgs_fs_parser.rs
@@ -1,0 +1,197 @@
+// Copyright (c) 2018 DDN. All rights reserved.
+// Use of this source code is governed by a MIT-style
+// license that can be found in the LICENSE file.
+
+use crate::{
+    base_parsers::{period, target, word},
+    types::{FsName, Param, Record, Target, TargetStat, TargetStats, TargetVariant},
+};
+use combine::{
+    attempt,
+    error::ParseError,
+    many1,
+    parser::char::{newline, string},
+    stream::Stream,
+    Parser,
+};
+use std::collections::HashMap;
+
+pub fn params() -> Vec<String> {
+    vec!["mgs.*.live.*".to_string()]
+}
+
+#[derive(Debug)]
+enum MgsFsStat {
+    MgsFsNames(Vec<(Target, FsName)>),
+}
+
+fn fsname<I>() -> impl Parser<I, Output = (Target, FsName)>
+where
+    I: Stream<Token = char>,
+    I::Error: ParseError<I::Token, I::Range, I::Position>,
+{
+    (
+        attempt(string("mgs")).skip(period()),
+        target().skip(period()),
+        string("live").skip(period()),
+        word().skip(newline()).map(FsName),
+    )
+        .map(|(_, target, _, fsname)| (target, fsname))
+}
+
+fn fsnames<I>() -> impl Parser<I, Output = Vec<(Target, FsName)>>
+where
+    I: Stream<Token = char>,
+    I::Error: ParseError<I::Token, I::Range, I::Position>,
+{
+    many1(fsname())
+}
+
+fn mgs_fs_stat<I>() -> impl Parser<I, Output = (Param, MgsFsStat)>
+where
+    I: Stream<Token = char>,
+    I::Error: ParseError<I::Token, I::Range, I::Position>,
+{
+    fsnames()
+        .map(|xs| {
+            let xs: Vec<(Target, FsName)> = xs
+                .into_iter()
+                .filter(|(_, name)| name.0 != "params")
+                .collect();
+
+            xs
+        })
+        .map(|xs| (Param("fsnames".into()), MgsFsStat::MgsFsNames(xs)))
+}
+
+pub fn parse<I>() -> impl Parser<I, Output = Vec<Record>>
+where
+    I: Stream<Token = char>,
+    I::Error: ParseError<I::Token, I::Range, I::Position>,
+{
+    (mgs_fs_stat())
+        .map(|(param, stat)| match stat {
+            MgsFsStat::MgsFsNames(xs) => {
+                let mgs_map: HashMap<Target, Vec<FsName>> =
+                    xs.into_iter()
+                        .fold(HashMap::new(), |mut acc, (target, fs_name)| {
+                            if let Some(fs_names) = acc.get(&target) {
+                                let names: Vec<FsName> =
+                                    [&fs_names[..], &vec![fs_name][..]].concat();
+                                acc.insert(target, names);
+                            } else {
+                                acc.insert(target, vec![fs_name]);
+                            }
+
+                            acc
+                        });
+
+                mgs_map
+                    .into_iter()
+                    .map(|(target, fs_name)| {
+                        TargetStats::FsNames(TargetStat {
+                            kind: TargetVariant::MGT,
+                            target: target,
+                            param: param.clone(),
+                            value: fs_name,
+                        })
+                    })
+                    .map(Record::Target)
+                    .collect::<Vec<_>>()
+            }
+        })
+        .message("while parsing mgs params")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use combine::{many, parser::EasyParser};
+
+    #[test]
+    fn test_single_mounted_fs() {
+        let x = r#"mgs.MGS.live.fs
+mgs.MGS.live.params
+"#;
+
+        let result: (Vec<_>, _) = many(parse()).easy_parse(x).unwrap();
+        let records = result.0.into_iter().flatten().collect::<Vec<Record>>();
+
+        assert_eq!(
+            vec![Record::Target(TargetStats::FsNames(TargetStat {
+                kind: TargetVariant::MGT,
+                param: Param("fsnames".into()),
+                target: Target("MGS".into()),
+                value: vec![FsName("fs".into())],
+            }))],
+            records
+        );
+    }
+
+    #[test]
+    fn test_multi_mounted_fs() {
+        let x = r#"mgs.MGS.live.fs
+mgs.MGS.live.fs2
+mgs.MGS.live.params
+"#;
+
+        let result: (Vec<_>, _) = many(parse()).easy_parse(x).unwrap();
+        let records = result.0.into_iter().flatten().collect::<Vec<Record>>();
+
+        assert_eq!(
+            vec![Record::Target(TargetStats::FsNames(TargetStat {
+                kind: TargetVariant::MGT,
+                param: Param("fsnames".into()),
+                target: Target("MGS".into()),
+                value: vec![FsName("fs".into()), FsName("fs2".into())],
+            }))],
+            records
+        );
+    }
+
+    #[test]
+    fn test_multi_target_multi_mounted_fs() {
+        let x = r#"mgs.MGS.live.fs
+mgs.MGS2.live.mgs2fs1
+mgs.MGS.live.fs2
+mgs.MGS.live.params
+mgs.MGS2.live.mgs2fs2
+"#;
+
+        let result: (Vec<_>, _) = many(parse()).easy_parse(x).unwrap();
+        let mut records = result.0.into_iter().flatten().collect::<Vec<Record>>();
+        records.sort_by(|a, b| {
+            let record_a = match a {
+                Record::Target(TargetStats::FsNames(x)) => x,
+                _ => panic!("Error getting target record."),
+            };
+            let record_b = match b {
+                Record::Target(TargetStats::FsNames(x)) => x,
+                _ => panic!("Error getting target record."),
+            };
+
+            let a1 = record_a.value[0].0.to_string();
+            let b1 = record_b.value[0].0.to_string();
+
+            a1.partial_cmp(&b1).unwrap()
+        });
+
+        assert_eq!(
+            vec![
+                Record::Target(TargetStats::FsNames(TargetStat {
+                    kind: TargetVariant::MGT,
+                    param: Param("fsnames".into()),
+                    target: Target("MGS".into()),
+                    value: vec![FsName("fs".into()), FsName("fs2".into())],
+                })),
+                Record::Target(TargetStats::FsNames(TargetStat {
+                    kind: TargetVariant::MGT,
+                    param: Param("fsnames".into()),
+                    target: Target("MGS2".into()),
+                    value: vec![FsName("mgs2fs1".into()), FsName("mgs2fs2".into())],
+                }))
+            ],
+            records
+        );
+    }
+}

--- a/src/mgs/mgs_fs_parser.rs
+++ b/src/mgs/mgs_fs_parser.rs
@@ -75,11 +75,10 @@ where
                 let mgs_map: HashMap<Target, Vec<FsName>> =
                     xs.into_iter()
                         .fold(HashMap::new(), |mut acc, (target, fs_name)| {
-                            let fs_names = acc.entry(target.clone()).or_insert(vec![]);
-                            let names: Vec<FsName> =
-                                [&fs_names[..], &vec![fs_name][..]].concat();
+                            let fs_names = acc.entry(target.clone()).or_insert_with(Vec::new);
+                            let names: Vec<FsName> = [&fs_names[..], &vec![fs_name][..]].concat();
                             acc.insert(target, names);
-                            
+
                             acc
                         });
 

--- a/src/mgs/mgs_parser.rs
+++ b/src/mgs/mgs_parser.rs
@@ -29,11 +29,14 @@ pub fn params() -> Vec<String> {
         format!("mgs.*.mgs.{}", THREADS_MIN),
         format!("mgs.*.mgs.{}", THREADS_STARTED),
         format!("mgs.*.{}", NUM_EXPORTS),
-        "-N mgs.MGS.live.*".to_string(),
     ]
     .iter()
     .map(|x| x.to_owned())
     .collect::<Vec<_>>()
+}
+
+pub fn name_only_params() -> Vec<String> {
+    vec!["mgs.MGS.live.*".to_string()]
 }
 
 #[derive(Debug)]
@@ -115,10 +118,7 @@ where
             string("live").skip(period()),
             word().skip(newline()),
             fsnames().map(|xs| {
-                let xs: Vec<String> = xs
-                    .into_iter()
-                    .filter(|name| *name != "params".to_string())
-                    .collect();
+                let xs: Vec<String> = xs.into_iter().filter(|name| name != "params").collect();
 
                 xs
             }),

--- a/src/mgs/mgs_parser.rs
+++ b/src/mgs/mgs_parser.rs
@@ -3,14 +3,13 @@
 // license that can be found in the LICENSE file.
 
 use crate::{
-    base_parsers::{digits, param, period, target, word},
+    base_parsers::{digits, param, period, target},
     stats_parser::stats,
     types::{Param, Record, Stat, Target, TargetStat, TargetStats, TargetVariant},
 };
 use combine::{
     attempt, choice,
     error::ParseError,
-    many1,
     parser::char::{newline, string},
     stream::Stream,
     Parser,

--- a/src/mgs/mod.rs
+++ b/src/mgs/mod.rs
@@ -2,4 +2,5 @@
 // Use of this source code is governed by a MIT-style
 // license that can be found in the LICENSE file.
 
+pub mod mgs_fs_parser;
 pub mod mgs_parser;

--- a/src/mgs/snapshots/lustre_collector__mgs__mgs_parser__tests__params.snap
+++ b/src/mgs/snapshots/lustre_collector__mgs__mgs_parser__tests__params.snap
@@ -1,0 +1,335 @@
+---
+source: src/mgs/mgs_parser.rs
+expression: result
+---
+(
+    [
+        Target(
+            Stats(
+                TargetStat {
+                    kind: MGT,
+                    param: Param(
+                        "stats",
+                    ),
+                    target: Target(
+                        "MGS",
+                    ),
+                    value: [
+                        Stat {
+                            name: "req_waittime",
+                            units: "usec",
+                            samples: 31280,
+                            min: Some(
+                                11,
+                            ),
+                            max: Some(
+                                2695,
+                            ),
+                            sum: Some(
+                                5020274,
+                            ),
+                            sumsquare: Some(
+                                1032267156,
+                            ),
+                        },
+                        Stat {
+                            name: "req_qdepth",
+                            units: "reqs",
+                            samples: 31280,
+                            min: Some(
+                                0,
+                            ),
+                            max: Some(
+                                1,
+                            ),
+                            sum: Some(
+                                56,
+                            ),
+                            sumsquare: Some(
+                                56,
+                            ),
+                        },
+                        Stat {
+                            name: "req_active",
+                            units: "reqs",
+                            samples: 31280,
+                            min: Some(
+                                1,
+                            ),
+                            max: Some(
+                                2,
+                            ),
+                            sum: Some(
+                                36625,
+                            ),
+                            sumsquare: Some(
+                                47315,
+                            ),
+                        },
+                        Stat {
+                            name: "req_timeout",
+                            units: "sec",
+                            samples: 31280,
+                            min: Some(
+                                1,
+                            ),
+                            max: Some(
+                                10,
+                            ),
+                            sum: Some(
+                                31289,
+                            ),
+                            sumsquare: Some(
+                                31379,
+                            ),
+                        },
+                        Stat {
+                            name: "reqbuf_avail",
+                            units: "bufs",
+                            samples: 85192,
+                            min: Some(
+                                62,
+                            ),
+                            max: Some(
+                                64,
+                            ),
+                            sum: Some(
+                                5364658,
+                            ),
+                            sumsquare: Some(
+                                337866142,
+                            ),
+                        },
+                        Stat {
+                            name: "ldlm_plain_enqueue",
+                            units: "reqs",
+                            samples: 201,
+                            min: Some(
+                                1,
+                            ),
+                            max: Some(
+                                1,
+                            ),
+                            sum: Some(
+                                201,
+                            ),
+                            sumsquare: Some(
+                                201,
+                            ),
+                        },
+                        Stat {
+                            name: "mgs_connect",
+                            units: "usec",
+                            samples: 9,
+                            min: Some(
+                                52,
+                            ),
+                            max: Some(
+                                5165,
+                            ),
+                            sum: Some(
+                                19362,
+                            ),
+                            sumsquare: Some(
+                                66639088,
+                            ),
+                        },
+                        Stat {
+                            name: "mgs_disconnect",
+                            units: "usec",
+                            samples: 4,
+                            min: Some(
+                                50,
+                            ),
+                            max: Some(
+                                92,
+                            ),
+                            sum: Some(
+                                265,
+                            ),
+                            sumsquare: Some(
+                                18709,
+                            ),
+                        },
+                        Stat {
+                            name: "mgs_target_reg",
+                            units: "usec",
+                            samples: 90,
+                            min: Some(
+                                874,
+                            ),
+                            max: Some(
+                                163383,
+                            ),
+                            sum: Some(
+                                1262544,
+                            ),
+                            sumsquare: Some(
+                                91852108168,
+                            ),
+                        },
+                        Stat {
+                            name: "mgs_config_read",
+                            units: "usec",
+                            samples: 41,
+                            min: Some(
+                                41,
+                            ),
+                            max: Some(
+                                2203,
+                            ),
+                            sum: Some(
+                                26823,
+                            ),
+                            sumsquare: Some(
+                                32448779,
+                            ),
+                        },
+                        Stat {
+                            name: "obd_ping",
+                            units: "usec",
+                            samples: 30339,
+                            min: Some(
+                                3,
+                            ),
+                            max: Some(
+                                4398,
+                            ),
+                            sum: Some(
+                                1552005,
+                            ),
+                            sumsquare: Some(
+                                134387261,
+                            ),
+                        },
+                        Stat {
+                            name: "llog_origin_handle_open",
+                            units: "usec",
+                            samples: 153,
+                            min: Some(
+                                29,
+                            ),
+                            max: Some(
+                                16443,
+                            ),
+                            sum: Some(
+                                25516,
+                            ),
+                            sumsquare: Some(
+                                270992222,
+                            ),
+                        },
+                        Stat {
+                            name: "llog_origin_handle_next_block",
+                            units: "usec",
+                            samples: 298,
+                            min: Some(
+                                24,
+                            ),
+                            max: Some(
+                                31952,
+                            ),
+                            sum: Some(
+                                141030,
+                            ),
+                            sumsquare: Some(
+                                2788155300,
+                            ),
+                        },
+                        Stat {
+                            name: "llog_origin_handle_read_header",
+                            units: "usec",
+                            samples: 145,
+                            min: Some(
+                                25,
+                            ),
+                            max: Some(
+                                44125,
+                            ),
+                            sum: Some(
+                                192095,
+                            ),
+                            sumsquare: Some(
+                                4905765639,
+                            ),
+                        },
+                    ],
+                },
+            ),
+        ),
+        Target(
+            ThreadsMax(
+                TargetStat {
+                    kind: MGT,
+                    param: Param(
+                        "threads_max",
+                    ),
+                    target: Target(
+                        "MGS",
+                    ),
+                    value: 32,
+                },
+            ),
+        ),
+        Target(
+            ThreadsMin(
+                TargetStat {
+                    kind: MGT,
+                    param: Param(
+                        "threads_min",
+                    ),
+                    target: Target(
+                        "MGS",
+                    ),
+                    value: 3,
+                },
+            ),
+        ),
+        Target(
+            ThreadsStarted(
+                TargetStat {
+                    kind: MGT,
+                    param: Param(
+                        "threads_started",
+                    ),
+                    target: Target(
+                        "MGS",
+                    ),
+                    value: 4,
+                },
+            ),
+        ),
+        Target(
+            NumExports(
+                TargetStat {
+                    kind: MGT,
+                    param: Param(
+                        "num_exports",
+                    ),
+                    target: Target(
+                        "MGS",
+                    ),
+                    value: 5,
+                },
+            ),
+        ),
+        Target(
+            FsNames(
+                TargetStat {
+                    kind: MGT,
+                    param: Param(
+                        "fsnames",
+                    ),
+                    target: Target(
+                        "MGS",
+                    ),
+                    value: [
+                        "fs",
+                        "fs2",
+                    ],
+                },
+            ),
+        ),
+    ],
+    "",
+)

--- a/src/mgs/snapshots/lustre_collector__mgs__mgs_parser__tests__params.snap
+++ b/src/mgs/snapshots/lustre_collector__mgs__mgs_parser__tests__params.snap
@@ -313,23 +313,6 @@ expression: result
                 },
             ),
         ),
-        Target(
-            FsNames(
-                TargetStat {
-                    kind: MGT,
-                    param: Param(
-                        "fsnames",
-                    ),
-                    target: Target(
-                        "MGS",
-                    ),
-                    value: [
-                        "fs",
-                        "fs2",
-                    ],
-                },
-            ),
-        ),
     ],
     "",
 )

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -4,7 +4,7 @@
 
 use crate::{
     mds::{client_count_parser, mds_parser},
-    mgs::{mgs_fs_parser, mgs_parser},
+    mgs::mgs_parser,
     oss::oss_parser,
     top_level_parser,
     types::Record,

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -20,6 +20,10 @@ pub fn params() -> Vec<String> {
     a
 }
 
+pub fn name_only_params() -> Vec<String> {
+    mgs_parser::name_only_params()
+}
+
 pub fn parse<I>() -> impl Parser<I, Output = Vec<Record>>
 where
     I: Stream<Token = char>,

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -20,10 +20,6 @@ pub fn params() -> Vec<String> {
     a
 }
 
-pub fn name_only_params() -> Vec<String> {
-    mgs_parser::name_only_params()
-}
-
 pub fn parse<I>() -> impl Parser<I, Output = Vec<Record>>
 where
     I: Stream<Token = char>,

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -4,7 +4,7 @@
 
 use crate::{
     mds::{client_count_parser, mds_parser},
-    mgs::mgs_parser,
+    mgs::{mgs_fs_parser, mgs_parser},
     oss::oss_parser,
     top_level_parser,
     types::Record,
@@ -29,6 +29,7 @@ where
         top_level_parser::parse().map(|x| vec![x]),
         client_count_parser::parse(),
         mgs_parser::parse().map(|x| vec![x]),
+        mgs_fs_parser::parse(),
         mds_parser::parse().map(|x| vec![x]),
         oss_parser::parse().map(|x| vec![x]),
     )))

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -29,7 +29,6 @@ where
         top_level_parser::parse().map(|x| vec![x]),
         client_count_parser::parse(),
         mgs_parser::parse().map(|x| vec![x]),
-        mgs_fs_parser::parse(),
         mds_parser::parse().map(|x| vec![x]),
         oss_parser::parse().map(|x| vec![x]),
     )))

--- a/src/types.rs
+++ b/src/types.rs
@@ -16,7 +16,7 @@ impl Deref for Host {
     }
 }
 
-#[derive(Debug, PartialEq, serde::Serialize, serde::Deserialize)]
+#[derive(Debug, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize)]
 /// The Lustre target cooresponding to these stats.
 pub struct Target(pub String);
 
@@ -28,7 +28,7 @@ impl Deref for Target {
     }
 }
 
-#[derive(Debug, PartialEq, serde::Serialize, serde::Deserialize)]
+#[derive(Clone, Debug, PartialEq, serde::Serialize, serde::Deserialize)]
 /// The name of the stat.
 pub struct Param(pub String);
 
@@ -295,6 +295,9 @@ pub enum NodeStats {
     SwapFree(NodeStat<u64>),
 }
 
+#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
+pub struct FsName(pub String);
+
 /// The target stats currently collected
 #[derive(PartialEq, Debug, serde::Serialize, serde::Deserialize)]
 pub enum TargetStats {
@@ -323,7 +326,7 @@ pub enum TargetStats {
     ConnectedClients(TargetStat<u64>),
     CtimeAgeLimit(TargetStat<u64>),
     EarlyLockCancel(TargetStat<u64>),
-    FsNames(TargetStat<Vec<String>>),
+    FsNames(TargetStat<Vec<FsName>>),
     LockCount(TargetStat<u64>),
     LockTimeouts(TargetStat<u64>),
     LockUnusedCount(TargetStat<u64>),

--- a/src/types.rs
+++ b/src/types.rs
@@ -323,6 +323,7 @@ pub enum TargetStats {
     ConnectedClients(TargetStat<u64>),
     CtimeAgeLimit(TargetStat<u64>),
     EarlyLockCancel(TargetStat<u64>),
+    FsNames(TargetStat<Vec<String>>),
     LockCount(TargetStat<u64>),
     LockTimeouts(TargetStat<u64>),
     LockUnusedCount(TargetStat<u64>),

--- a/src/types.rs
+++ b/src/types.rs
@@ -16,7 +16,7 @@ impl Deref for Host {
     }
 }
 
-#[derive(Debug, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize)]
+#[derive(Clone, Debug, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize)]
 /// The Lustre target cooresponding to these stats.
 pub struct Target(pub String);
 


### PR DESCRIPTION
Implement a new parser in lustre_collector that can take the output of lctl get_param -N mgs.MGS.live.* and parse it to show filesystem layouts

Signed-off-by: johnsonw <wjohnson@whamcloud.com>