### PR TITLE
Remove parsing global and peers section from lnet

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -156,7 +156,7 @@ checksum = "7fb9b38af92608140b86b693604b9ffcc5824240a484d1ecd4795bacb2fe88f3"
 
 [[package]]
 name = "lustre_collector"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "clap",
  "combine",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,10 +1,10 @@
 [package]
 authors = ["IML Team <iml@whamcloud.com>"]
 description = "Scrapes Lustre stats and aggregates into JSON or YAML"
-edition = "2018"
+edition = "2021"
 license = "MIT"
 name = "lustre_collector"
-version = "0.4.0"
+version = "0.5.0"
 
 [dependencies]
 clap = "2.33"

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ![rust](https://github.com/whamcloud/lustre-collector/workflows/rust/badge.svg?branch=master)
 
-![Crates.io](https://img.shields.io/crates/v/lustre_collector) ![docs.rs](https://docs.rs/lustre_collector/badge.svg?version=0.4.0)
+![Crates.io](https://img.shields.io/crates/v/lustre_collector) ![docs.rs](https://docs.rs/lustre_collector/badge.svg?version=0.5.0)
 
 This repo provides a parsed representation of common Lustre statistics.
 

--- a/lustre_collector.spec
+++ b/lustre_collector.spec
@@ -1,5 +1,5 @@
 Name: lustre_collector
-Version: 0.3.0
+Version: 0.5.0
 # Release Start
 Release: 1%{?dist}
 # Release End

--- a/src/lnetctl_parser.rs
+++ b/src/lnetctl_parser.rs
@@ -3,12 +3,14 @@
 // license that can be found in the LICENSE file.
 
 use crate::{
-    types::{
-        lnet_exports::{LNetExport, Net},
-        LNetStat, LNetStats, Param, Record,
-    },
+    types::{lnet_exports::Net, LNetStat, LNetStats, Param, Record},
     LustreCollectorError,
 };
+
+#[derive(serde::Serialize, serde::Deserialize)]
+struct LnetNetStats {
+    net: Option<Vec<Net>>,
+}
 
 pub(crate) fn build_lnet_stats(x: &Net) -> Vec<Record> {
     x.local_nis
@@ -43,7 +45,7 @@ pub fn parse(x: &str) -> Result<Vec<Record>, LustreCollectorError> {
         return Ok(vec![]);
     }
 
-    let y: LNetExport = serde_yaml::from_str(x)?;
+    let y: LnetNetStats = serde_yaml::from_str(x)?;
 
     Ok(y.net
         .map(|x| x.iter().flat_map(build_lnet_stats).collect())
@@ -69,26 +71,7 @@ mod tests {
     - net:
           errno: -100
           descr: "cannot get networks: Network is down"
-show:
-    - route:
-          errno: -100
-          descr: "cannot get routes: Network is down"
-show:
-    - routing:
-          errno: -100
-          descr: "cannot get routing information: Network is down"
-show:
-    - peer:
-          errno: -100
-          descr: "cannot get peer list: Network is down"
-show:
-    - global:
-          errno: -100
-          descr: "cannot get numa_range: Unknown error -100"
-global:
-    max_intf: 200
-    discovery: 1
-    drop_asym_route: 0"#,
+"#,
         )
         .unwrap();
 
@@ -96,7 +79,163 @@ global:
     }
 
     #[test]
-    fn test_lnet_export_parse() {
+    fn test_lnet_parse2() {
+        let x = parse(
+            r#"net:
+    - net type: lo
+      local NI(s):
+        - nid: 0@lo
+          status: up
+          statistics:
+              send_count: 0
+              recv_count: 0
+              drop_count: 0
+          sent_stats:
+              put: 0
+              get: 0
+              reply: 0
+              ack: 0
+              hello: 0
+          received_stats:
+              put: 0
+              get: 0
+              reply: 0
+              ack: 0
+              hello: 0
+          dropped_stats:
+              put: 0
+              get: 0
+              reply: 0
+              ack: 0
+              hello: 0
+          health stats:
+              fatal_error: 0
+              health value: 0
+              interrupts: 0
+              dropped: 0
+              aborted: 0
+              no route: 0
+              timeouts: 0
+              error: 0
+          tunables:
+              peer_timeout: 0
+              peer_credits: 0
+              peer_buffer_credits: 0
+              credits: 0
+          dev cpt: 0
+          CPT: "[0,1,2,3,4]"
+    - net type: o2ib
+      local NI(s):
+        - nid: 172.16.0.24@o2ib
+          status: up
+          interfaces:
+              0: ib0
+          statistics:
+              send_count: 0
+              recv_count: 0
+              drop_count: 0
+          sent_stats:
+              put: 0
+              get: 0
+              reply: 0
+              ack: 0
+              hello: 0
+          received_stats:
+              put: 0
+              get: 0
+              reply: 0
+              ack: 0
+              hello: 0
+          dropped_stats:
+              put: 0
+              get: 0
+              reply: 0
+              ack: 0
+              hello: 0
+          health stats:
+              fatal_error: 0
+              health value: 1000
+              interrupts: 0
+              dropped: 0
+              aborted: 0
+              no route: 0
+              timeouts: 0
+              error: 0
+          tunables:
+              peer_timeout: 180
+              peer_credits: 32
+              peer_buffer_credits: 0
+              credits: 256
+              peercredits_hiw: 16
+              map_on_demand: 0
+              concurrent_sends: 64
+              fmr_pool_size: 512
+              fmr_flush_trigger: 384
+              fmr_cache: 1
+              ntx: 512
+              conns_per_peer: 1
+          lnd tunables:
+          dev cpt: -1
+          CPT: "[0,1,2,3,4]"
+        - nid: 172.16.0.28@o2ib
+          status: up
+          interfaces:
+              0: ib1
+          statistics:
+              send_count: 0
+              recv_count: 0
+              drop_count: 0
+          sent_stats:
+              put: 0
+              get: 0
+              reply: 0
+              ack: 0
+              hello: 0
+          received_stats:
+              put: 0
+              get: 0
+              reply: 0
+              ack: 0
+              hello: 0
+          dropped_stats:
+              put: 0
+              get: 0
+              reply: 0
+              ack: 0
+              hello: 0
+          health stats:
+              fatal_error: 0
+              health value: 1000
+              interrupts: 0
+              dropped: 0
+              aborted: 0
+              no route: 0
+              timeouts: 0
+              error: 0
+          tunables:
+              peer_timeout: 180
+              peer_credits: 32
+              peer_buffer_credits: 0
+              credits: 256
+              peercredits_hiw: 16
+              map_on_demand: 0
+              concurrent_sends: 64
+              fmr_pool_size: 512
+              fmr_flush_trigger: 384
+              fmr_cache: 1
+              ntx: 512
+              conns_per_peer: 1
+          lnd tunables:
+          dev cpt: -1
+          CPT: "[0,1,2,3,4]""#,
+        )
+        .unwrap();
+
+        assert_debug_snapshot!(x);
+    }
+
+    #[test]
+    fn test_lnet_net_parse() {
         let x = parse(
             r#"net:
     - net type: lo
@@ -185,172 +324,7 @@ global:
           dev cpt: -1
           tcp bonding: 0
           CPT: "[0]"
-peer:
-    - primary nid: 0@lo
-      Multi-Rail: False
-      peer ni:
-        - nid: 0@lo
-          state: NA
-          max_ni_tx_credits: 0
-          available_tx_credits: 0
-          min_tx_credits: 0
-          tx_q_num_of_buf: 0
-          available_rtr_credits: 0
-          min_rtr_credits: 0
-          refcount: 1
-          statistics:
-              send_count: 0
-              recv_count: 942
-              drop_count: 0
-          sent_stats:
-              put: 0
-              get: 0
-              reply: 0
-              ack: 0
-              hello: 0
-          received_stats:
-              put: 930
-              get: 0
-              reply: 0
-              ack: 12
-              hello: 0
-          dropped_stats:
-              put: 0
-              get: 0
-              reply: 0
-              ack: 0
-              hello: 0
-          health stats:
-              health value: 1000
-              dropped: 0
-              timeout: 0
-              error: 0
-              network timeout: 0
-    - primary nid: 10.73.20.12@tcp
-      Multi-Rail: True
-      peer ni:
-        - nid: 10.73.20.12@tcp
-          state: NA
-          max_ni_tx_credits: 8
-          available_tx_credits: 8
-          min_tx_credits: 5
-          tx_q_num_of_buf: 0
-          available_rtr_credits: 8
-          min_rtr_credits: 8
-          refcount: 1
-          statistics:
-              send_count: 1628
-              recv_count: 1628
-              drop_count: 0
-          sent_stats:
-              put: 1626
-              get: 2
-              reply: 0
-              ack: 0
-              hello: 0
-          received_stats:
-              put: 1596
-              get: 1
-              reply: 1
-              ack: 30
-              hello: 0
-          dropped_stats:
-              put: 0
-              get: 0
-              reply: 0
-              ack: 0
-              hello: 0
-          health stats:
-              health value: 1000
-              dropped: 3
-              timeout: 0
-              error: 7
-              network timeout: 0
-    - primary nid: 10.73.20.21@tcp
-      Multi-Rail: True
-      peer ni:
-        - nid: 10.73.20.21@tcp
-          state: NA
-          max_ni_tx_credits: 8
-          available_tx_credits: 8
-          min_tx_credits: 1
-          tx_q_num_of_buf: 0
-          available_rtr_credits: 8
-          min_rtr_credits: 8
-          refcount: 1
-          statistics:
-              send_count: 1226
-              recv_count: 1201
-              drop_count: 0
-          sent_stats:
-              put: 1225
-              get: 1
-              reply: 0
-              ack: 0
-              hello: 0
-          received_stats:
-              put: 1198
-              get: 0
-              reply: 1
-              ack: 2
-              hello: 0
-          dropped_stats:
-              put: 0
-              get: 0
-              reply: 0
-              ack: 0
-              hello: 0
-          health stats:
-              health value: 1000
-              dropped: 8
-              timeout: 0
-              error: 30
-              network timeout: 0
-    - primary nid: 10.73.20.22@tcp
-      Multi-Rail: True
-      peer ni:
-        - nid: 10.73.20.22@tcp
-          state: NA
-          max_ni_tx_credits: 8
-          available_tx_credits: 8
-          min_tx_credits: 2
-          tx_q_num_of_buf: 0
-          available_rtr_credits: 8
-          min_rtr_credits: 8
-          refcount: 1
-          statistics:
-              send_count: 971
-              recv_count: 907
-              drop_count: 0
-          sent_stats:
-              put: 970
-              get: 1
-              reply: 0
-              ack: 0
-              hello: 0
-          received_stats:
-              put: 904
-              get: 0
-              reply: 1
-              ack: 2
-              hello: 0
-          dropped_stats:
-              put: 0
-              get: 0
-              reply: 0
-              ack: 0
-              hello: 0
-          health stats:
-              health value: 1000
-              dropped: 8
-              timeout: 0
-              error: 28
-              network timeout: 0
-global:
-    numa_range: 0
-    max_intf: 200
-    discovery: 1
-    drop_asym_route: 0"#,
+"#,
         )
         .unwrap();
 
@@ -443,380 +417,7 @@ global:
               credits: 256
           dev cpt: -1
           CPT: "[0,1,2,3,4]"
-peer:
-    - primary nid: 172.16.252.131@o2ib
-      Multi-Rail: False
-      peer ni:
-        - nid: 172.16.252.131@o2ib
-          state: NA
-          max_ni_tx_credits: 0
-          available_tx_credits: 0
-          min_tx_credits: 0
-          tx_q_num_of_buf: 0
-          available_rtr_credits: 0
-          min_rtr_credits: 0
-          refcount: 2
-          statistics:
-              send_count: 0
-              recv_count: 0
-              drop_count: 0
-          sent_stats:
-              put: 0
-              get: 0
-              reply: 0
-              ack: 0
-              hello: 0
-          received_stats:
-              put: 0
-              get: 0
-              reply: 0
-              ack: 0
-              hello: 0
-          dropped_stats:
-              put: 0
-              get: 0
-              reply: 0
-              ack: 0
-              hello: 0
-          health stats:
-              health value: 1000
-              dropped: 0
-              timeout: 0
-              error: 0
-              network timeout: 0
-    - primary nid: 0@lo
-      Multi-Rail: False
-      peer ni:
-        - nid: 0@lo
-          state: NA
-          max_ni_tx_credits: 0
-          available_tx_credits: 0
-          min_tx_credits: 0
-          tx_q_num_of_buf: 0
-          available_rtr_credits: 0
-          min_rtr_credits: 0
-          refcount: 1
-          statistics:
-              send_count: 0
-              recv_count: 8
-              drop_count: 0
-          sent_stats:
-              put: 0
-              get: 0
-              reply: 0
-              ack: 0
-              hello: 0
-          received_stats:
-              put: 8
-              get: 0
-              reply: 0
-              ack: 0
-              hello: 0
-          dropped_stats:
-              put: 0
-              get: 0
-              reply: 0
-              ack: 0
-              hello: 0
-          health stats:
-              health value: 1000
-              dropped: 0
-              timeout: 0
-              error: 0
-              network timeout: 0
-    - primary nid: 172.16.253.131@o2ib
-      Multi-Rail: False
-      peer ni:
-        - nid: 172.16.253.131@o2ib
-          state: NA
-          max_ni_tx_credits: 0
-          available_tx_credits: 0
-          min_tx_credits: 0
-          tx_q_num_of_buf: 0
-          available_rtr_credits: 0
-          min_rtr_credits: 0
-          refcount: 2
-          statistics:
-              send_count: 0
-              recv_count: 0
-              drop_count: 0
-          sent_stats:
-              put: 0
-              get: 0
-              reply: 0
-              ack: 0
-              hello: 0
-          received_stats:
-              put: 0
-              get: 0
-              reply: 0
-              ack: 0
-              hello: 0
-          dropped_stats:
-              put: 0
-              get: 0
-              reply: 0
-              ack: 0
-              hello: 0
-          health stats:
-              health value: 1000
-              dropped: 0
-              timeout: 0
-              error: 0
-              network timeout: 0
-    - primary nid: 172.16.252.133@o2ib
-      Multi-Rail: False
-      peer ni:
-        - nid: 172.16.252.133@o2ib
-          state: NA
-          max_ni_tx_credits: 0
-          available_tx_credits: 0
-          min_tx_credits: 0
-          tx_q_num_of_buf: 0
-          available_rtr_credits: 0
-          min_rtr_credits: 0
-          refcount: 2
-          statistics:
-              send_count: 0
-              recv_count: 0
-              drop_count: 0
-          sent_stats:
-              put: 0
-              get: 0
-              reply: 0
-              ack: 0
-              hello: 0
-          received_stats:
-              put: 0
-              get: 0
-              reply: 0
-              ack: 0
-              hello: 0
-          dropped_stats:
-              put: 0
-              get: 0
-              reply: 0
-              ack: 0
-              hello: 0
-          health stats:
-              health value: 1000
-              dropped: 0
-              timeout: 0
-              error: 0
-              network timeout: 0
-    - primary nid: 172.16.253.130@o2ib
-      Multi-Rail: False
-      peer ni:
-        - nid: 172.16.253.130@o2ib
-          state: NA
-          max_ni_tx_credits: 0
-          available_tx_credits: 0
-          min_tx_credits: 0
-          tx_q_num_of_buf: 0
-          available_rtr_credits: 0
-          min_rtr_credits: 0
-          refcount: 2
-          statistics:
-              send_count: 0
-              recv_count: 0
-              drop_count: 0
-          sent_stats:
-              put: 0
-              get: 0
-              reply: 0
-              ack: 0
-              hello: 0
-          received_stats:
-              put: 0
-              get: 0
-              reply: 0
-              ack: 0
-              hello: 0
-          dropped_stats:
-              put: 0
-              get: 0
-              reply: 0
-              ack: 0
-              hello: 0
-          health stats:
-              health value: 1000
-              dropped: 0
-              timeout: 0
-              error: 0
-              network timeout: 0
-    - primary nid: 172.16.253.132@o2ib
-      Multi-Rail: False
-      peer ni:
-        - nid: 172.16.253.132@o2ib
-          state: NA
-          max_ni_tx_credits: 0
-          available_tx_credits: 0
-          min_tx_credits: 0
-          tx_q_num_of_buf: 0
-          available_rtr_credits: 0
-          min_rtr_credits: 0
-          refcount: 2
-          statistics:
-              send_count: 0
-              recv_count: 0
-              drop_count: 0
-          sent_stats:
-              put: 0
-              get: 0
-              reply: 0
-              ack: 0
-              hello: 0
-          received_stats:
-              put: 0
-              get: 0
-              reply: 0
-              ack: 0
-              hello: 0
-          dropped_stats:
-              put: 0
-              get: 0
-              reply: 0
-              ack: 0
-              hello: 0
-          health stats:
-              health value: 1000
-              dropped: 0
-              timeout: 0
-              error: 0
-              network timeout: 0
-    - primary nid: 172.16.252.130@o2ib
-      Multi-Rail: False
-      peer ni:
-        - nid: 172.16.252.130@o2ib
-          state: NA
-          max_ni_tx_credits: 0
-          available_tx_credits: 0
-          min_tx_credits: 0
-          tx_q_num_of_buf: 0
-          available_rtr_credits: 0
-          min_rtr_credits: 0
-          refcount: 2
-          statistics:
-              send_count: 0
-              recv_count: 0
-              drop_count: 0
-          sent_stats:
-              put: 0
-              get: 0
-              reply: 0
-              ack: 0
-              hello: 0
-          received_stats:
-              put: 0
-              get: 0
-              reply: 0
-              ack: 0
-              hello: 0
-          dropped_stats:
-              put: 0
-              get: 0
-              reply: 0
-              ack: 0
-              hello: 0
-          health stats:
-              health value: 1000
-              dropped: 0
-              timeout: 0
-              error: 0
-              network timeout: 0
-    - primary nid: 172.16.253.133@o2ib
-      Multi-Rail: False
-      peer ni:
-        - nid: 172.16.253.133@o2ib
-          state: NA
-          max_ni_tx_credits: 0
-          available_tx_credits: 0
-          min_tx_credits: 0
-          tx_q_num_of_buf: 0
-          available_rtr_credits: 0
-          min_rtr_credits: 0
-          refcount: 2
-          statistics:
-              send_count: 0
-              recv_count: 0
-              drop_count: 0
-          sent_stats:
-              put: 0
-              get: 0
-              reply: 0
-              ack: 0
-              hello: 0
-          received_stats:
-              put: 0
-              get: 0
-              reply: 0
-              ack: 0
-              hello: 0
-          dropped_stats:
-              put: 0
-              get: 0
-              reply: 0
-              ack: 0
-              hello: 0
-          health stats:
-              health value: 1000
-              dropped: 0
-              timeout: 0
-              error: 0
-              network timeout: 0
-    - primary nid: 172.16.252.132@o2ib
-      Multi-Rail: False
-      peer ni:
-        - nid: 172.16.252.132@o2ib
-          state: NA
-          max_ni_tx_credits: 0
-          available_tx_credits: 0
-          min_tx_credits: 0
-          tx_q_num_of_buf: 0
-          available_rtr_credits: 0
-          min_rtr_credits: 0
-          refcount: 2
-          statistics:
-              send_count: 0
-              recv_count: 0
-              drop_count: 0
-          sent_stats:
-              put: 0
-              get: 0
-              reply: 0
-              ack: 0
-              hello: 0
-          received_stats:
-              put: 0
-              get: 0
-              reply: 0
-              ack: 0
-              hello: 0
-          dropped_stats:
-              put: 0
-              get: 0
-              reply: 0
-              ack: 0
-              hello: 0
-          health stats:
-              health value: 1000
-              dropped: 0
-              timeout: 0
-              error: 0
-              network timeout: 0
-global:
-    numa_range: 0
-    max_intf: 200
-    discovery: 1
-    drop_asym_route: 0
-    retry_count: 2
-    transaction_timeout: 50
-    health_sensitivity: 100
-    recovery_interval: 1
-    router_sensitivity: 100
-    lnd_timeout: 16
-    response_tracking: 3
-    recovery_limit: 0"#,
+"#,
         )
         .unwrap();
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -57,7 +57,7 @@ fn main() {
         .collect::<Vec<_>>();
 
     let matches = App::new("lustre_collector")
-        .version("0.4.0")
+        .version("0.5.0")
         .author("IML Team")
         .about("Grabs various Lustre statistics for display in JSON or YAML")
         .arg(
@@ -96,7 +96,7 @@ fn main() {
         });
 
     let lnetctl_output = Command::new("lnetctl")
-        .arg("export")
+        .args(["net", "show", "-v", "4"])
         .output()
         .expect("failed to get lnetctl stats");
 

--- a/src/snapshots/lustre_collector__lnetctl_parser__tests__lnet_net_parse.snap
+++ b/src/snapshots/lustre_collector__lnetctl_parser__tests__lnet_net_parse.snap
@@ -1,6 +1,7 @@
 ---
 source: src/lnetctl_parser.rs
 expression: x
+
 ---
 [
     LNetStat(

--- a/src/snapshots/lustre_collector__lnetctl_parser__tests__lnet_parse2.snap
+++ b/src/snapshots/lustre_collector__lnetctl_parser__tests__lnet_parse2.snap
@@ -1,0 +1,106 @@
+---
+source: src/lnetctl_parser.rs
+expression: x
+
+---
+[
+    LNetStat(
+        SendCount(
+            LNetStat {
+                nid: "0@lo",
+                param: Param(
+                    "send_count",
+                ),
+                value: 0,
+            },
+        ),
+    ),
+    LNetStat(
+        RecvCount(
+            LNetStat {
+                nid: "0@lo",
+                param: Param(
+                    "recv_count",
+                ),
+                value: 0,
+            },
+        ),
+    ),
+    LNetStat(
+        DropCount(
+            LNetStat {
+                nid: "0@lo",
+                param: Param(
+                    "drop_count",
+                ),
+                value: 0,
+            },
+        ),
+    ),
+    LNetStat(
+        SendCount(
+            LNetStat {
+                nid: "172.16.0.24@o2ib",
+                param: Param(
+                    "send_count",
+                ),
+                value: 0,
+            },
+        ),
+    ),
+    LNetStat(
+        RecvCount(
+            LNetStat {
+                nid: "172.16.0.24@o2ib",
+                param: Param(
+                    "recv_count",
+                ),
+                value: 0,
+            },
+        ),
+    ),
+    LNetStat(
+        DropCount(
+            LNetStat {
+                nid: "172.16.0.24@o2ib",
+                param: Param(
+                    "drop_count",
+                ),
+                value: 0,
+            },
+        ),
+    ),
+    LNetStat(
+        SendCount(
+            LNetStat {
+                nid: "172.16.0.28@o2ib",
+                param: Param(
+                    "send_count",
+                ),
+                value: 0,
+            },
+        ),
+    ),
+    LNetStat(
+        RecvCount(
+            LNetStat {
+                nid: "172.16.0.28@o2ib",
+                param: Param(
+                    "recv_count",
+                ),
+                value: 0,
+            },
+        ),
+    ),
+    LNetStat(
+        DropCount(
+            LNetStat {
+                nid: "172.16.0.28@o2ib",
+                param: Param(
+                    "drop_count",
+                ),
+                value: 0,
+            },
+        ),
+    ),
+]

--- a/src/types.rs
+++ b/src/types.rs
@@ -208,13 +208,6 @@ pub mod lnet_exports {
     }
 
     #[derive(serde::Serialize, serde::Deserialize)]
-    pub struct LNetExport {
-        pub net: Option<Vec<Net>>,
-        pub peer: Option<Vec<Peer>>,
-        pub global: Option<Global>,
-    }
-
-    #[derive(serde::Serialize, serde::Deserialize)]
     pub struct LNetStatistics {
         pub send_count: i64,
         pub recv_count: i64,


### PR DESCRIPTION
We don't currently use the global and peers section from `lnetctl
export`. Replace it with `lnetctl net show -v 4`.

Signed-off-by: Joe Grund <jgrund@whamcloud.io>