### PR TITLE
Fix jobstats format

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -22,6 +22,8 @@ pub enum LustreCollectorError {
     Utf8Error(#[from] str::Utf8Error),
     #[error("{0}")]
     ConversionError(String),
+    #[error("Cannot convert timestamp {0} to a u64 of milliseconds")]
+    InvalidTime(String),
 }
 
 impl From<combine::stream::easy::Errors<char, &str, usize>> for LustreCollectorError {

--- a/src/mds/job_stats.rs
+++ b/src/mds/job_stats.rs
@@ -35,7 +35,7 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::types::BytesStat;
+    use crate::{types::BytesStat, UnsignedLustreTimestamp};
 
     #[test]
     fn test_yaml_deserialize() {
@@ -65,7 +65,9 @@ mod tests {
         let expected = JobStatsMdt {
             job_stats: Some(vec![JobStatMdt {
                 job_id: "touch.0".to_string(),
-                snapshot_time: 1_614_767_417,
+                snapshot_time: UnsignedLustreTimestamp(1_614_767_417),
+                start_time: None,
+                elapsed_time: None,
                 open: BytesStat {
                     samples: 1,
                     unit: "usecs".to_string(),

--- a/src/oss/job_stats.rs
+++ b/src/oss/job_stats.rs
@@ -35,7 +35,10 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::types::{BytesStat, ReqsStat};
+    use crate::{
+        types::{BytesStat, ReqsStat},
+        UnsignedLustreTimestamp,
+    };
 
     #[test]
     fn test_yaml_deserialize() {
@@ -58,7 +61,9 @@ mod tests {
         let expected = JobStatsOst {
             job_stats: Some(vec![JobStatOst {
                 job_id: "cp.0".to_string(),
-                snapshot_time: 1_537_070_542,
+                snapshot_time: UnsignedLustreTimestamp(1_537_070_542),
+                start_time: None,
+                elapsed_time: None,
                 read_bytes: BytesStat {
                     samples: 256,
                     unit: "bytes".to_string(),
@@ -117,5 +122,31 @@ mod tests {
         };
 
         assert_eq!(serde_yaml::from_str::<JobStatsOst>(x).unwrap(), expected)
+    }
+
+    #[test]
+    fn with_time_triple() {
+        let x = r#"job_stats:
+- job_id:          lfs.0.
+  snapshot_time:   1686153914.643122579 secs.nsecs
+  start_time:      1686153914.643119181 secs.nsecs
+  elapsed_time:    0.000003398 secs.nsecs
+  read_bytes:      { samples:           0, unit: bytes, min:        0, max:        0, sum:                0, sumsq:                  0, hist: {  } }
+  write_bytes:     { samples:           0, unit: bytes, min:        0, max:        0, sum:                0, sumsq:                  0, hist: {  } }
+  read:            { samples:           0, unit: usecs, min:        0, max:        0, sum:                0, sumsq:                  0 }
+  write:           { samples:           0, unit: usecs, min:        0, max:        0, sum:                0, sumsq:                  0 }
+  getattr:         { samples:           0, unit: usecs, min:        0, max:        0, sum:                0, sumsq:                  0 }
+  setattr:         { samples:           0, unit: usecs, min:        0, max:        0, sum:                0, sumsq:                  0 }
+  punch:           { samples:           0, unit: usecs, min:        0, max:        0, sum:                0, sumsq:                  0 }
+  sync:            { samples:           0, unit: usecs, min:        0, max:        0, sum:                0, sumsq:                  0 }
+  destroy:         { samples:           0, unit: usecs, min:        0, max:        0, sum:                0, sumsq:                  0 }
+  create:          { samples:           0, unit: usecs, min:        0, max:        0, sum:                0, sumsq:                  0 }
+  statfs:          { samples:           1, unit: usecs, min:        1, max:        1, sum:                1, sumsq:                  1 }
+  get_info:        { samples:           0, unit: usecs, min:        0, max:        0, sum:                0, sumsq:                  0 }
+  set_info:        { samples:           0, unit: usecs, min:        0, max:        0, sum:                0, sumsq:                  0 }
+  quotactl:        { samples:           0, unit: usecs, min:        0, max:        0, sum:                0, sumsq:                  0 }
+  prealloc:        { samples:           0, unit: usecs, min:        0, max:        0, sum:                0, sumsq:                  0 }"#;
+
+        insta::assert_debug_snapshot!(serde_yaml::from_str::<JobStatsOst>(x).unwrap());
     }
 }

--- a/src/oss/snapshots/lustre_collector__oss__job_stats__tests__with_time_triple.snap
+++ b/src/oss/snapshots/lustre_collector__oss__job_stats__tests__with_time_triple.snap
@@ -1,0 +1,78 @@
+---
+source: src/oss/job_stats.rs
+expression: "serde_yaml::from_str::<JobStatsOst>(x).unwrap()"
+---
+JobStatsOst {
+    job_stats: Some(
+        [
+            JobStatOst {
+                job_id: "lfs.0.",
+                snapshot_time: UnsignedLustreTimestamp(
+                    1686153914643,
+                ),
+                start_time: Some(
+                    UnsignedLustreTimestamp(
+                        1686153914643,
+                    ),
+                ),
+                elapsed_time: Some(
+                    "0.000003398 secs.nsecs",
+                ),
+                read_bytes: BytesStat {
+                    samples: 0,
+                    unit: "bytes",
+                    min: 0,
+                    max: 0,
+                    sum: 0,
+                },
+                write_bytes: BytesStat {
+                    samples: 0,
+                    unit: "bytes",
+                    min: 0,
+                    max: 0,
+                    sum: 0,
+                },
+                getattr: ReqsStat {
+                    samples: 0,
+                    unit: "usecs",
+                },
+                setattr: ReqsStat {
+                    samples: 0,
+                    unit: "usecs",
+                },
+                punch: ReqsStat {
+                    samples: 0,
+                    unit: "usecs",
+                },
+                sync: ReqsStat {
+                    samples: 0,
+                    unit: "usecs",
+                },
+                destroy: ReqsStat {
+                    samples: 0,
+                    unit: "usecs",
+                },
+                create: ReqsStat {
+                    samples: 0,
+                    unit: "usecs",
+                },
+                statfs: ReqsStat {
+                    samples: 1,
+                    unit: "usecs",
+                },
+                get_info: ReqsStat {
+                    samples: 0,
+                    unit: "usecs",
+                },
+                set_info: ReqsStat {
+                    samples: 0,
+                    unit: "usecs",
+                },
+                quotactl: ReqsStat {
+                    samples: 0,
+                    unit: "usecs",
+                },
+            },
+        ],
+    ),
+}

--- a/src/types.rs
+++ b/src/types.rs
@@ -3,7 +3,7 @@
 // license that can be found in the LICENSE file.
 
 use crate::LustreCollectorError;
-use std::{fmt, ops::Deref};
+use std::{fmt, ops::Deref, time::Duration};
 
 #[derive(Debug, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 /// The hostname cooresponding to these stats.
@@ -61,10 +61,56 @@ pub struct JobStatsOst {
     pub job_stats: Option<Vec<JobStatOst>>,
 }
 
+/// Used to represent an unsigned timestamp in Lustre.
+///
+/// Only use this field whne you are sure that the timestamp is unsigned.
+#[derive(PartialEq, Eq, Debug, serde::Serialize, serde::Deserialize)]
+#[serde(try_from = "String")]
+pub struct UnsignedLustreTimestamp(pub i64);
+
+impl TryFrom<String> for UnsignedLustreTimestamp {
+    type Error = LustreCollectorError;
+
+    fn try_from(s: String) -> Result<Self, Self::Error> {
+        if let Ok(i) = s.parse::<i64>() {
+            return Ok(Self(i));
+        }
+
+        let (time, _) = s
+            .split_once(' ')
+            .ok_or_else(|| LustreCollectorError::InvalidTime(s.to_string()))?;
+
+        let (secs, ns) = time
+            .split_once('.')
+            .ok_or_else(|| LustreCollectorError::InvalidTime(s.to_string()))?;
+
+        let secs = secs
+            .parse::<u64>()
+            .map_err(|_| LustreCollectorError::InvalidTime(s.to_string()))?;
+
+        let ns = ns
+            .parse::<u32>()
+            .map_err(|_| LustreCollectorError::InvalidTime(s.to_string()))?;
+
+        let d = Duration::new(secs, ns);
+
+        let millis = u64::from(d.subsec_millis());
+
+        let sec_millis = d.as_secs() * 1_000;
+
+        let millis = i64::try_from(sec_millis + millis)
+            .map_err(|_| LustreCollectorError::InvalidTime(s.to_string()))?;
+
+        Ok(Self(millis))
+    }
+}
+
 #[derive(PartialEq, Eq, Debug, serde::Serialize, serde::Deserialize)]
 pub struct JobStatOst {
     pub job_id: String,
-    pub snapshot_time: i64,
+    pub snapshot_time: UnsignedLustreTimestamp,
+    pub start_time: Option<UnsignedLustreTimestamp>,
+    pub elapsed_time: Option<String>,
     pub read_bytes: BytesStat,
     pub write_bytes: BytesStat,
     pub getattr: ReqsStat,
@@ -87,7 +133,9 @@ pub struct JobStatsMdt {
 #[derive(PartialEq, Eq, Debug, serde::Serialize, serde::Deserialize)]
 pub struct JobStatMdt {
     pub job_id: String,
-    pub snapshot_time: i64,
+    pub snapshot_time: UnsignedLustreTimestamp,
+    pub start_time: Option<UnsignedLustreTimestamp>,
+    pub elapsed_time: Option<String>,
     pub open: BytesStat,
     pub close: BytesStat,
     pub mknod: BytesStat,


### PR DESCRIPTION
jobstats has gained `start_time` and `elapsed_time` fields. and the format has changed to require more parsing.

Add these fields in a backwards compatible way, and re-convert timestamp like fields to a newtype of i64.