### PR TITLE
Add new 'block maps msec' brw_stats

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -267,7 +267,7 @@ checksum = "b06a4cde4c0f271a446782e3eff8de789548ce57dbc8eca9292c27f4a42004b4"
 
 [[package]]
 name = "lustre_collector"
-version = "0.7.4"
+version = "0.7.5"
 dependencies = [
  "clap",
  "combine",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ description = "Scrapes Lustre stats and aggregates into JSON or YAML"
 edition = "2021"
 license = "MIT"
 name = "lustre_collector"
-version = "0.7.4"
+version = "0.7.5"
 
 [dependencies]
 clap = {version = "4", features = ["derive"]}

--- a/fixtures/osd.txt
+++ b/fixtures/osd.txt
@@ -114,3 +114,29 @@ I/O time (1/1000s)     ios   % cum % |  ios         % cum %
 
                            read      |     write
 disk I/O size          ios   % cum % |  ios         % cum %
+osd-ldiskfs.exa01-OST0013.brw_stats=
+snapshot_time:            1698140569.773721492 secs.nsecs
+
+                           read      |     write
+pages per bulk r/w     rpcs  % cum % |  rpcs        % cum %
+
+                           read      |     write
+discontiguous pages    rpcs  % cum % |  rpcs        % cum %
+
+                           read      |     write
+discontiguous blocks   rpcs  % cum % |  rpcs        % cum %
+
+                           read      |     write
+disk fragmented I/Os   ios   % cum % |  ios         % cum %
+
+                           read      |     write
+disk I/Os in flight    ios   % cum % |  ios         % cum %
+
+                           read      |     write
+I/O time (1/1000s)     ios   % cum % |  ios         % cum %
+
+                           read      |     write
+disk I/O size          ios   % cum % |  ios         % cum %
+
+                           read      |     write
+block maps msec        maps  % cum % |  maps        % cum %

--- a/src/brw_stats_parser.rs
+++ b/src/brw_stats_parser.rs
@@ -57,6 +57,7 @@ where
         attempt(string_to("disk I/Os in flight", "rpc_hist")),
         attempt(string_to("I/O time (1/1000s)", "io_time")),
         attempt(string_to("disk I/O size", "disk_iosize")),
+        attempt(string_to("block maps msec", "block_maps_msec")),
     ]);
 
     (keys.skip(spaces()), word().skip(till_newline())).map(|(name, unit)| BrwStats {

--- a/src/mgs/mgs_fs_parser.rs
+++ b/src/mgs/mgs_fs_parser.rs
@@ -75,7 +75,7 @@ where
                 let mgs_map: HashMap<Target, Vec<FsName>> =
                     xs.into_iter()
                         .fold(HashMap::new(), |mut acc, (target, fs_name)| {
-                            let fs_names = acc.entry(target.clone()).or_insert_with(Vec::new);
+                            let fs_names = acc.entry(target.clone()).or_default();
                             let names: Vec<FsName> = [&fs_names[..], &vec![fs_name][..]].concat();
                             acc.insert(target, names);
 

--- a/src/snapshots/lustre_collector__osd_parser__tests__osd_stats.snap
+++ b/src/snapshots/lustre_collector__osd_parser__tests__osd_stats.snap
@@ -540,6 +540,61 @@ expression: result
                 },
             ),
         ),
+        Target(
+            BrwStats(
+                TargetStat {
+                    kind: Ost,
+                    param: Param(
+                        "brw_stats",
+                    ),
+                    target: Target(
+                        "exa01-OST0013",
+                    ),
+                    value: [
+                        BrwStats {
+                            name: "pages",
+                            unit: "rpcs",
+                            buckets: [],
+                        },
+                        BrwStats {
+                            name: "discont_pages",
+                            unit: "rpcs",
+                            buckets: [],
+                        },
+                        BrwStats {
+                            name: "discont_blocks",
+                            unit: "rpcs",
+                            buckets: [],
+                        },
+                        BrwStats {
+                            name: "dio_frags",
+                            unit: "ios",
+                            buckets: [],
+                        },
+                        BrwStats {
+                            name: "rpc_hist",
+                            unit: "ios",
+                            buckets: [],
+                        },
+                        BrwStats {
+                            name: "io_time",
+                            unit: "ios",
+                            buckets: [],
+                        },
+                        BrwStats {
+                            name: "disk_iosize",
+                            unit: "ios",
+                            buckets: [],
+                        },
+                        BrwStats {
+                            name: "block_maps_msec",
+                            unit: "maps",
+                            buckets: [],
+                        },
+                    ],
+                },
+            ),
+        ),
     ],
     "",
 )


### PR DESCRIPTION
Latest Lustre version include a new `block maps msec` stat for `brw_stats`

See updated snapshot