### PR TITLE
Do not print buffer remainder in error

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,10 +28,12 @@ use std::{io, str};
 pub use types::*;
 
 fn check_output(records: Vec<Record>, state: &str) -> Result<Vec<Record>, LustreCollectorError> {
+    let params = crate::parser::params().join(" ");
+
     if !state.is_empty() {
         return Err(io::Error::new(
             io::ErrorKind::InvalidInput,
-            format!("Content left in input buffer: {}", state),
+            format!("Content left in input buffer. Please run and supply to support: `lctl get_param {params}`"),
         )
         .into());
     }

--- a/src/node_stats_parsers.rs
+++ b/src/node_stats_parsers.rs
@@ -28,10 +28,12 @@ pub fn parse_cpustats_output(output: &[u8]) -> Result<Vec<Record>, LustreCollect
         .easy_parse(output)
         .map_err(|err| err.map_position(|p| p.translate_position(output)))?;
 
+    let params = crate::parser::params().join(" ");
+
     if !state.is_empty() {
         return Err(io::Error::new(
             io::ErrorKind::InvalidInput,
-            format!("Content left in input buffer: {}", state),
+            format!("Content left in input buffer. Please run and supply output to support: `lctl get_param {params}`"),
         )
         .into());
     }
@@ -80,10 +82,12 @@ pub fn parse_meminfo_output(output: &[u8]) -> Result<Vec<Record>, LustreCollecto
         .easy_parse(output)
         .map_err(|err| err.map_position(|p| p.translate_position(output)))?;
 
+    let params = crate::parser::params().join(" ");
+
     if !state.is_empty() {
         return Err(io::Error::new(
             io::ErrorKind::InvalidInput,
-            format!("Content left in input buffer: {}", state),
+            format!("Content left in input buffer. Please run and supply output to support: `lctl get_param {params}`"),
         )
         .into());
     }


### PR DESCRIPTION
We should not print buffer remainder in our error output as it can be exeedingly large.

Instead, provide a message of how to reproduce the failing output.